### PR TITLE
Expose opponent hand and deck sizes in handler data

### DIFF
--- a/spec/helpers/handler-data-builder.ts
+++ b/spec/helpers/handler-data-builder.ts
@@ -40,8 +40,8 @@ export class HandlerDataBuilder {
          * This is a partial representation - only includes properties needed for canApply tests
          */
         const data = {
-            deck: 0,
-            hand: [],
+            deck: { sizes: [ 0, 0 ] },
+            hand: { hand: [], sizes: [ 0, 0 ] },
             field: { creatures: [[], []] },
             turnCounter: { turnNumber: 2 },
             turnState: { 
@@ -97,7 +97,7 @@ export class HandlerDataBuilder {
      */
     static withDeck(size: number): HandlerDataCustomizer {
         return (data: HandlerData) => {
-            data.deck = size;
+            data.deck = { sizes: [ size, size ] };
         };
     }
 
@@ -107,11 +107,12 @@ export class HandlerDataBuilder {
      */
     static withHand(cards: Array<{ templateId: string, type?: GameCard['type'] }>): HandlerDataCustomizer {
         return (data: HandlerData) => {
-            data.hand = cards.map((card, index) => ({
+            const hand = cards.map((card, index) => ({
                 instanceId: `${card.templateId}-hand-${index}`,
                 templateId: card.templateId,
-                type: card.type || 'creature',
+                type: card.type || 'creature' as GameCard['type'],
             }));
+            data.hand = { hand, sizes: [ hand.length, 0 ] };
         };
     }
 

--- a/src/controllers/deck-controller.ts
+++ b/src/controllers/deck-controller.ts
@@ -24,11 +24,15 @@ export class DeckControllerProvider implements GenericControllerProvider<GameCar
     }
 }
 
+export type DeckHandlerData = {
+    sizes: number[];
+};
+
 /*
  * TODO: Handler should know what cards are remaining but not in order - need to make this clear to handlers
  * This is important for maintaining game integrity while providing necessary information
  */
-export class DeckController extends AbstractController<GameCard[][], DeckDependencies, number> {
+export class DeckController extends AbstractController<GameCard[][], DeckDependencies, DeckHandlerData> {
     private playerCount: number = 0;
 
     private nextCardInstanceId: number = 1;
@@ -128,10 +132,12 @@ export class DeckController extends AbstractController<GameCard[][], DeckDepende
     
     /*
      * Required by AbstractController
-     * Return only the deck size, not the full deck data
+     * Return deck sizes for all players (public knowledge), not the actual cards.
      */
-    getFor(position: number): number {
-        return this.getDeckSize(position);
+    getFor(_position: number): DeckHandlerData {
+        return {
+            sizes: this.state.map(d => d.length),
+        };
     }
     
     // Required by AbstractController

--- a/src/controllers/hand-controller.ts
+++ b/src/controllers/hand-controller.ts
@@ -27,7 +27,12 @@ export class HandControllerProvider implements GenericControllerProvider<GameCar
     }
 }
 
-export class HandController extends AbstractController<GameCard[][], HandDependencies, GameCard[]> {
+export type HandHandlerData = {
+    hand: GameCard[];
+    sizes: number[];
+};
+
+export class HandController extends AbstractController<GameCard[][], HandDependencies, HandHandlerData> {
     initialize(playerCount: number): void {
         this.state = new Array(playerCount).fill(undefined)
             .map(() => []);
@@ -143,8 +148,11 @@ export class HandController extends AbstractController<GameCard[][], HandDepende
     }
     
     // Required by AbstractController
-    getFor(position: number): GameCard[] {
-        return this.getHand(position);
+    getFor(position: number): HandHandlerData {
+        return {
+            hand: this.getHand(position),
+            sizes: this.state.map(h => h.length),
+        };
     }
     
     // Remove specific cards from hand and discard them

--- a/src/effects/action-validator.ts
+++ b/src/effects/action-validator.ts
@@ -124,7 +124,7 @@ export class ActionValidator {
      * Checks if a card can be played.
      */
     static canPlayCard(handlerData: HandlerData, cardRepository: CardRepository, cardId: string, playerId: number): boolean {
-        const hand = handlerData.hand;
+        const hand = handlerData.hand.hand;
         const cardIndex = hand.findIndex(card => card.templateId === cardId);
         
         if (cardIndex === -1) {

--- a/src/effects/handlers/draw-effect-handler.ts
+++ b/src/effects/handlers/draw-effect-handler.ts
@@ -22,7 +22,7 @@ export class DrawEffectHandler extends AbstractEffectHandler<DrawEffect> {
         const playerId = context.sourcePlayer;
         
         // Get the deck size from handler data
-        const deckSize = handlerData.deck;
+        const deckSize = handlerData.deck.sizes[playerId];
         
         /*
          * If the deck is completely empty, don't allow playing draw effects that require drawing

--- a/src/effects/handlers/evolution-acceleration-effect-handler.ts
+++ b/src/effects/handlers/evolution-acceleration-effect-handler.ts
@@ -54,7 +54,7 @@ export class EvolutionAccelerationEffectHandler extends AbstractEffectHandler<Ev
             }
             
             // Check if there's a valid Stage 2 evolution in hand
-            const hand = handlerData.hand;
+            const hand = handlerData.hand.hand;
             const targetCreatureData = cardRepository.getCreature(getCurrentTemplateId(targetCreature));
             const hasValidEvolution = hand.some(card => {
                 if (card.type !== 'creature') {

--- a/src/effects/handlers/search-effect-handler.ts
+++ b/src/effects/handlers/search-effect-handler.ts
@@ -43,7 +43,7 @@ export class SearchEffectHandler extends AbstractEffectHandler<SearchEffect> {
         
         // For deck searches, check if deck has cards
         if (location === 'deck') {
-            const deckSize = handlerData.deck;
+            const deckSize = handlerData.deck.sizes[context.sourcePlayer];
             return deckSize > 0;
         }
         

--- a/src/effects/handlers/swap-cards-effect-handler.ts
+++ b/src/effects/handlers/swap-cards-effect-handler.ts
@@ -33,8 +33,8 @@ export class SwapCardsEffectHandler extends AbstractEffectHandler<SwapCardsEffec
      */
     canApply(handlerData: HandlerData, effect: SwapCardsEffect, context: EffectContext, cardRepository: CardRepository): boolean {
         // Check if player has cards in hand to discard OR cards in deck to draw
-        const hasCardsToDiscard = handlerData.hand.length > 0;
-        const hasCardsToDraw = handlerData.deck > 0;
+        const hasCardsToDiscard = handlerData.hand.hand.length > 0;
+        const hasCardsToDraw = handlerData.deck.sizes[context.sourcePlayer] > 0;
         
         // Effect can be applied if either discarding or drawing would happen
         return hasCardsToDiscard || hasCardsToDraw;

--- a/src/handlers/default-bot-handler.ts
+++ b/src/handlers/default-bot-handler.ts
@@ -18,7 +18,7 @@ export class DefaultBotHandler extends GameHandler {
         const currentPlayer = handlerData.turn;
         
         // Get the player's hand
-        const hand = handlerData.hand;
+        const hand = handlerData.hand.hand;
         
         // First try to play a creature card to the bench if possible
         const creatureCards = hand.filter(card => card.type === 'creature');
@@ -130,9 +130,7 @@ export class DefaultBotHandler extends GameHandler {
     }
     
     handleSetup(handlerData: HandlerData, responsesQueue: HandlerResponsesQueue<ResponseMessage>): void {
-        const hand = handlerData.hand;
-        
-        // Find all creature cards in hand
+        const hand = handlerData.hand.hand;
         const creatureCards = hand.filter(card => card.type === 'creature');
         
         if (creatureCards.length > 0) {

--- a/src/handlers/intermediary-handler-helpers.ts
+++ b/src/handlers/intermediary-handler-helpers.ts
@@ -160,7 +160,7 @@ export async function handlePlayCard(cardRepository: CardRepository, intermediar
     const currentPlayer = handlerData.turn;
     
     // Get the player's hand
-    const hand = handlerData.hand;
+    const hand = handlerData.hand.hand;
     
     if (!hand || hand.length === 0) {
         await intermediary.form({ type: 'print', message: [ 'Your hand is empty. Wait for your next turn to draw a card.' ] });
@@ -710,7 +710,7 @@ export async function handleAction(cardRepository: CardRepository, intermediary:
  * @param playerId The player ID
  */
 export async function showPlayerStatus(cardRepository: CardRepository, intermediary: Intermediary, handlerData: HandlerData, playerId: number): Promise<void> {
-    const hand = handlerData.hand;
+    const hand = handlerData.hand.hand;
     const activeFieldCard = toFieldCard(handlerData.field.creatures[playerId][0]); // Position 0 is active
     const benchedFieldCards = handlerData.field.creatures[playerId].slice(1).map(toFieldCard); // Positions 1+ are benched
     const supporterPlayed = handlerData.turnState.supporterPlayedThisTurn;

--- a/src/handlers/intermediary-handler.ts
+++ b/src/handlers/intermediary-handler.ts
@@ -75,7 +75,7 @@ export class IntermediaryHandler extends GameHandler {
     
     async handleSetup(handlerData: HandlerData, responsesQueue: HandlerResponsesQueue<ResponseMessage>): Promise<void> {
         const currentPlayer = handlerData.turn;
-        const hand = handlerData.hand;
+        const hand = handlerData.hand.hand;
         
         await this.intermediary.form({
             type: 'print',

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,7 @@ export { IntermediaryHandler } from './handlers/intermediary-handler.js';
 
 // Export card types and repository for custom card definitions
 export * from './repository/index.js';
+
+// Export handler data types for external consumers (e.g. ISMCTS adapters)
+export type { HandHandlerData } from './controllers/hand-controller.js';
+export type { DeckHandlerData } from './controllers/deck-controller.js';


### PR DESCRIPTION
HandController.getFor() now returns HandHandlerData { hand: GameCard[], sizes: number[] } instead of just the current player's GameCard[]. The new shape gives external consumers (e.g. the ISMCTS adapter) the public hand-count for every player alongside the acting player's actual cards.

DeckController.getFor() now returns DeckHandlerData { sizes: number[] } instead of a bare number, so all players' remaining deck counts are visible in the same way.

All in-repo callers (effect handlers, action validator, bot/UI handlers) updated to use handlerData.hand.hand and handlerData.deck.sizes[player].

Both new types are re-exported from the package's public index.