### PR TITLE
Add TryThenEffect: gate second effect on first succeeding

### DIFF
--- a/spec/effects/handlers/try-then.spec.ts
+++ b/spec/effects/handlers/try-then.spec.ts
@@ -1,0 +1,78 @@
+import { expect } from 'chai';
+import { AttackResponseMessage } from '../../../src/messages/response/attack-response-message.js';
+import { StateBuilder } from '../../helpers/state-builder.js';
+import { runTestGame } from '../../helpers/test-helpers.js';
+import { MockCardRepository } from '../../mock-repository.js';
+
+describe('Try-Then Effect', () => {
+    const testRepository = new MockCardRepository({
+        creatures: {
+            'try-then-attacker': {
+                templateId: 'try-then-attacker',
+                name: 'Try-Then Attacker',
+                maxHp: 100,
+                type: 'colorless',
+                retreatCost: 1,
+                attacks: [{
+                    name: 'Soul Shot',
+                    damage: 0,
+                    energyRequirements: [],
+                    effects: [{
+                        type: 'try-then',
+                        attempt: {
+                            type: 'hand-discard',
+                            amount: { type: 'constant', value: 1 },
+                            target: 'self',
+                        },
+                        then: {
+                            type: 'hp',
+                            amount: { type: 'constant', value: 70 },
+                            target: { type: 'fixed', player: 'opponent', position: 'active' },
+                            operation: 'damage',
+                        },
+                    }],
+                }],
+            },
+            defender: {
+                templateId: 'defender',
+                name: 'Defender',
+                maxHp: 200,
+                type: 'colorless',
+                retreatCost: 1,
+                attacks: [{ name: 'Basic Attack', damage: 10, energyRequirements: [] }],
+            },
+        },
+    });
+
+    it('fires both attempt and then when attacker has cards in hand', () => {
+        const { state } = runTestGame({
+            actions: [ new AttackResponseMessage(0) ],
+            customRepository: testRepository,
+            stateCustomizer: StateBuilder.combine(
+                StateBuilder.withCreatures(0, 'try-then-attacker'),
+                StateBuilder.withCreatures(1, 'defender'),
+                StateBuilder.withHand(0, [{ templateId: 'defender', type: 'creature' }]),
+            ),
+        });
+
+        // Attempt (discard 1) succeeded → then (70 damage) fires
+        expect(state.field.creatures[1][0].damageTaken).to.equal(70, 'Should deal 70 damage when hand has cards');
+        // Attacker's hand should be empty after discarding
+        expect(state.hand[0].length).to.equal(0, 'Should have discarded the card from hand');
+    });
+
+    it('blocks both attempt and then when attacker has no cards in hand', () => {
+        const { state } = runTestGame({
+            actions: [ new AttackResponseMessage(0) ],
+            customRepository: testRepository,
+            stateCustomizer: StateBuilder.combine(
+                StateBuilder.withCreatures(0, 'try-then-attacker'),
+                StateBuilder.withCreatures(1, 'defender'),
+                StateBuilder.withHand(0, []),
+            ),
+        });
+
+        // Attempt (discard 1) failed → neither effect fires
+        expect(state.field.creatures[1][0].damageTaken).to.equal(0, 'Should deal no damage when hand is empty');
+    });
+});

--- a/src/effects/handlers/choice-delegation-effect-handler.ts
+++ b/src/effects/handlers/choice-delegation-effect-handler.ts
@@ -2,6 +2,9 @@ import { Controllers } from '../../controllers/controllers.js';
 import { ChoiceDelegationEffect } from '../../repository/effect-types.js';
 import { EffectContext } from '../effect-context.js';
 import { AbstractEffectHandler, ResolutionRequirement } from '../interfaces/effect-handler-interface.js';
+import { HandlerData } from '../../game-handler.js';
+import { CardRepository } from '../../repository/card-repository.js';
+import { EffectApplier } from '../effect-applier.js';
 
 /**
  * Handler for choice delegation effects.
@@ -15,6 +18,10 @@ import { AbstractEffectHandler, ResolutionRequirement } from '../interfaces/effe
 export class ChoiceDelegationEffectHandler extends AbstractEffectHandler<ChoiceDelegationEffect> {
     getResolutionRequirements(_effect: ChoiceDelegationEffect): ResolutionRequirement[] {
         return [];
+    }
+
+    canApply(handlerData: HandlerData, effect: ChoiceDelegationEffect, context: EffectContext, cardRepository: CardRepository): boolean {
+        return effect.options.some(option => option.effects.length > 0 && option.effects.some(e => EffectApplier.canApplyEffect(e, handlerData, context, cardRepository)));
     }
 
     apply(controllers: Controllers, effect: ChoiceDelegationEffect, context: EffectContext): void {

--- a/src/effects/handlers/conditional-delegation-effect-handler.ts
+++ b/src/effects/handlers/conditional-delegation-effect-handler.ts
@@ -3,6 +3,9 @@ import { ConditionalDelegationEffect } from '../../repository/effect-types.js';
 import { EffectContext } from '../effect-context.js';
 import { AbstractEffectHandler, ResolutionRequirement } from '../interfaces/effect-handler-interface.js';
 import { getEffectValue } from '../effect-utils.js';
+import { HandlerData } from '../../game-handler.js';
+import { CardRepository } from '../../repository/card-repository.js';
+import { EffectApplier } from '../effect-applier.js';
 
 /**
  * Handler for conditional delegation effects.
@@ -19,6 +22,11 @@ import { getEffectValue } from '../effect-utils.js';
 export class ConditionalDelegationEffectHandler extends AbstractEffectHandler<ConditionalDelegationEffect> {
     getResolutionRequirements(_effect: ConditionalDelegationEffect): ResolutionRequirement[] {
         return [];
+    }
+
+    canApply(handlerData: HandlerData, effect: ConditionalDelegationEffect, context: EffectContext, cardRepository: CardRepository): boolean {
+        const checkBranch = (effects: ConditionalDelegationEffect['trueEffects']) => effects.length > 0 && effects.some(e => EffectApplier.canApplyEffect(e, handlerData, context, cardRepository));
+        return checkBranch(effect.trueEffects) || checkBranch(effect.falseEffects);
     }
 
     apply(controllers: Controllers, effect: ConditionalDelegationEffect, context: EffectContext): void {

--- a/src/effects/handlers/effect-handlers-map.ts
+++ b/src/effects/handlers/effect-handlers-map.ts
@@ -21,6 +21,7 @@ import { conditionalDelegationEffectHandler } from './conditional-delegation-eff
 import { choiceDelegationEffectHandler } from './choice-delegation-effect-handler.js';
 import { passiveEffectHandler } from './passive-effect-handler.js';
 import { delayedEffectHandler } from './delayed-effect-handler.js';
+import { tryThenEffectHandler } from './try-then-effect-handler.js';
 
 export const effectHandlers: EffectHandlerMap = {
     hp: hpEffectHandler,
@@ -43,6 +44,7 @@ export const effectHandlers: EffectHandlerMap = {
     'pull-evolution': pullEvolutionEffectHandler,
     'conditional-delegation': conditionalDelegationEffectHandler,
     'choice-delegation': choiceDelegationEffectHandler,
+    'try-then': tryThenEffectHandler,
     delayed: delayedEffectHandler,
     passive: passiveEffectHandler,
 };

--- a/src/effects/handlers/hand-discard-effect-handler.ts
+++ b/src/effects/handlers/hand-discard-effect-handler.ts
@@ -4,19 +4,26 @@ import { EffectContext } from '../effect-context.js';
 import { AbstractEffectHandler, ResolutionRequirement } from '../effect-handler.js';
 import { getEffectValue } from '../effect-utils.js';
 import { GameCard } from '../../controllers/card-types.js';
+import { HandlerData } from '../../game-handler.js';
 
 /**
  * Handler for hand discard effects that discard cards from a player's hand.
  */
 export class HandDiscardEffectHandler extends AbstractEffectHandler<HandDiscardEffect> {
-    /**
-     * Hand discard effects don't have targets to resolve.
-     * 
-     * @param effect The hand discard effect
-     * @returns Empty array as hand discard effects don't have targets
-     */
-    getResolutionRequirements(effect: HandDiscardEffect): ResolutionRequirement[] {
+    getResolutionRequirements(_effect: HandDiscardEffect): ResolutionRequirement[] {
         return [];
+    }
+
+    /** Returns false when the player has no cards to discard, blocking TRY_THEN gating. */
+    canApply(handlerData: HandlerData, effect: HandDiscardEffect, context: EffectContext): boolean {
+        if (effect.target === 'both') {
+            return true; 
+        }
+        if (effect.target === 'self') {
+            return handlerData.hand.hand.length > 0; 
+        }
+        // opponent — use sizes array (handlerData.hand.hand is scoped to sourcePlayer)
+        return handlerData.hand.sizes[1 - context.sourcePlayer] > 0;
     }
     
     /**

--- a/src/effects/handlers/try-then-effect-handler.ts
+++ b/src/effects/handlers/try-then-effect-handler.ts
@@ -1,0 +1,59 @@
+import { Controllers } from '../../controllers/controllers.js';
+import { HandlerData } from '../../game-handler.js';
+import { TryThenEffect } from '../../repository/effect-types.js';
+import { CardRepository } from '../../repository/card-repository.js';
+import { EffectContext } from '../effect-context.js';
+import { AbstractEffectHandler, ResolutionRequirement, isEnergyResolutionTarget } from '../interfaces/effect-handler-interface.js';
+import { FieldTargetResolver } from '../target-resolvers/field-target-resolver.js';
+import { EnergyTargetResolver } from '../target-resolvers/energy-target-resolver.js';
+// Imported at call-time only; safe with ESM live bindings despite the cycle
+// (effect-handlers-map → this file → effect-handlers-map).
+import { effectHandlers } from './effect-handlers-map.js';
+
+/**
+ * Handler for try-then effects.
+ * Checks whether `attempt` can be applied; if so, enqueues [attempt, then] together.
+ * If `attempt` cannot be applied, neither effect fires — modelling "Discard X. If you do, …"
+ */
+export class TryThenEffectHandler extends AbstractEffectHandler<TryThenEffect> {
+    getResolutionRequirements(_effect: TryThenEffect): ResolutionRequirement[] {
+        return [];
+    }
+
+    canApply(handlerData: HandlerData, effect: TryThenEffect, context: EffectContext, cardRepository: CardRepository): boolean {
+        const attempt = effect.attempt;
+        const handler = effectHandlers[attempt.type as keyof typeof effectHandlers];
+        if (!handler) {
+            return false;
+        }
+
+        // Check required resolution targets for the attempt effect
+        const requirements = (handler as { getResolutionRequirements(e: typeof attempt): ResolutionRequirement[] })
+            .getResolutionRequirements(attempt);
+        for (const req of requirements) {
+            if (!req.required) {
+                continue; 
+            }
+            const available = isEnergyResolutionTarget(req.target)
+                ? EnergyTargetResolver.isTargetAvailable(req.target, handlerData, context, cardRepository)
+                : FieldTargetResolver.isTargetAvailable(req.target, handlerData, context, cardRepository);
+            if (!available) {
+                return false; 
+            }
+        }
+
+        // Delegate to the attempt handler's own canApply if present
+        const attemptHandler = handler as { canApply?(hd: HandlerData, e: typeof attempt, ctx: EffectContext, cr: CardRepository): boolean };
+        if (attemptHandler.canApply) {
+            return attemptHandler.canApply(handlerData, attempt, context, cardRepository);
+        }
+
+        return true;
+    }
+
+    apply(controllers: Controllers, effect: TryThenEffect, context: EffectContext): void {
+        controllers.effects.pushPendingEffect([ effect.attempt, effect.then ], context);
+    }
+}
+
+export const tryThenEffectHandler = new TryThenEffectHandler();

--- a/src/repository/effect-types.ts
+++ b/src/repository/effect-types.ts
@@ -372,6 +372,22 @@ export type DelayedEffect<TContextualRefs extends string = string> = {
 };
 
 /**
+ * Attempts the first effect; if it can be applied, also applies the second.
+ * If the attempt cannot be applied (canApply returns false or required targets are
+ * unavailable), neither effect fires. Models card text like "Discard X. If you do, …"
+ * @property {string} type - Always 'try-then' to identify this effect type
+ * @property {Effect} attempt - The effect to attempt; gates whether `then` runs
+ * @property {Effect} then - The effect to apply only if `attempt` succeeds
+ * @example { type: 'try-then', attempt: { type: 'hand-discard', ... }, then: { type: 'hp', ... } }
+ * // Discard a card from your hand. If you do, deal damage.
+ */
+export type TryThenEffect<TContextualRefs extends string = string> = {
+    type: 'try-then';
+    attempt: Effect<TContextualRefs>;
+    then: Effect<TContextualRefs>;
+};
+
+/**
  * Immediate effects that are resolved immediately and don't persist over time.
  * These effects typically modify game state directly (e.g., draw cards, deal damage).
  *
@@ -399,7 +415,8 @@ export type ImmediateEffect<TContextualRefs extends string = string> =
     | RemoveFieldCardEffect<TContextualRefs>
     | PullEvolutionEffect<TContextualRefs>
     | ConditionalDelegationEffect<TContextualRefs>
-    | ChoiceDelegationEffect<TContextualRefs>;
+    | ChoiceDelegationEffect<TContextualRefs>
+    | TryThenEffect<TContextualRefs>;
 
 /**
  * Represents an effect that prevents playing specific card types.


### PR DESCRIPTION
Models card text like "Discard X. If you do, draw a card." The attempt effect's canApply is checked before firing either effect; if it returns false (e.g. empty hand), neither runs. HandDiscardEffect, ConditionalDelegationEffectHandler, and ChoiceDelegationEffectHandler each gain canApply implementations to support this gating.