### PR TITLE
Tighten passive effect arrays to RegisterPassiveEffect[]

### DIFF
--- a/src/repository/card-types.ts
+++ b/src/repository/card-types.ts
@@ -1,4 +1,4 @@
-import { Effect } from './effect-types.js';
+import { Effect, RegisterPassiveEffect } from './effect-types.js';
 import { EffectValue } from './effect-value-types.js';
 
 /**
@@ -56,7 +56,9 @@ type CreatureAbilityForTrigger<T extends Trigger> = {
     name: string;
     description?: string;
     trigger: T;
-    effects: Effect<TriggerContextualRefs[T['type']]>[];
+    effects: T['type'] extends 'passive'
+        ? RegisterPassiveEffect[]
+        : Effect<TriggerContextualRefs[T['type']]>[];
 };
 
 /**
@@ -82,8 +84,7 @@ type ToolDataBase = {
 
 /** @internal ToolData variant without a trigger (passive modifier effects only) */
 type ToolDataNoTrigger = ToolDataBase & {
-    /** Passive modifier effects — no contextual refs available */
-    effects: Effect<never>[];
+    effects: RegisterPassiveEffect[];
     trigger?: undefined;
 };
 


### PR DESCRIPTION
ToolDataNoTrigger.effects and passive CreatureAbility.effects were typed as Effect<never>[], which accepts any effect with no contextual refs — including non-passive effects that would be semantically wrong. Narrowing both to RegisterPassiveEffect[] enforces the invariant at the type level: only passive modifier effects can appear in positions that are applied continuously rather than on demand.