### PR TITLE
Fix energy-transfer to sweep all matching sources

### DIFF
--- a/src/effects/handlers/energy-transfer-effect-handler.ts
+++ b/src/effects/handlers/energy-transfer-effect-handler.ts
@@ -59,56 +59,36 @@ export class EnergyTransferEffectHandler extends AbstractEffectHandler<EnergyTra
             throw new Error(`Expected resolved target, got ${resolvedTarget?.type || 'undefined'}`);
         }
 
-        const sourceFieldTarget = resolvedSource.targets[0];
         const targetFieldTarget = resolvedTarget.targets[0];
-
-        // Get the source creature
-        const sourceCreature = controllers.field.getRawCardByPosition(sourceFieldTarget.playerId, sourceFieldTarget.fieldIndex);
-        
-        if (!sourceCreature) {
-            controllers.players.messageAll({
-                type: 'status',
-                components: [ `${context.effectName} source creature not found!` ],
-            });
-            return;
-        }
-
-        // Get the target creature
-        const targetCreature = controllers.field.getRawCardByPosition(targetFieldTarget.playerId, targetFieldTarget.fieldIndex);
-        
-        if (!targetCreature) {
-            controllers.players.messageAll({
-                type: 'status',
-                components: [ `${context.effectName} target creature not found!` ],
-            });
-            return;
-        }
-
-        const sourceInstanceId = controllers.field.getFieldInstanceId(sourceFieldTarget.playerId, sourceFieldTarget.fieldIndex);
         const targetInstanceId = controllers.field.getFieldInstanceId(targetFieldTarget.playerId, targetFieldTarget.fieldIndex);
 
-        if (!sourceInstanceId || !targetInstanceId) {
+        if (!targetInstanceId) {
             controllers.players.messageAll({
                 type: 'status',
-                components: [ `${context.effectName} could not resolve transfer targets!` ],
+                components: [ `${context.effectName} could not resolve transfer target!` ],
             });
             return;
         }
 
-        const selectedEnergy = resolvedSource.targets[0].energy;
         let transferred = 0;
-        for (const [ energyType, amount ] of Object.entries(selectedEnergy) as Array<[ AttachableEnergyType, number ]>) {
-            if (amount > 0 && controllers.energy.transferEnergyBetweenInstances(
-                sourceInstanceId,
-                targetInstanceId,
-                energyType,
-                amount,
-            )) {
-                transferred += amount;
+        for (const sourceTarget of resolvedSource.targets) {
+            const sourceInstanceId = controllers.field.getFieldInstanceId(sourceTarget.playerId, sourceTarget.fieldIndex);
+            if (!sourceInstanceId) {
+                continue; 
+            }
+
+            for (const [ energyType, amount ] of Object.entries(sourceTarget.energy) as Array<[ AttachableEnergyType, number ]>) {
+                if (amount > 0 && controllers.energy.transferEnergyBetweenInstances(
+                    sourceInstanceId,
+                    targetInstanceId,
+                    energyType,
+                    amount,
+                )) {
+                    transferred += amount;
+                }
             }
         }
 
-        // Send a message about the transfer
         if (transferred > 0) {
             controllers.players.messageAll({
                 type: 'status',

--- a/src/effects/target-resolvers/energy-target-resolver.ts
+++ b/src/effects/target-resolvers/energy-target-resolver.ts
@@ -181,16 +181,17 @@ export class EnergyTargetResolver {
             if (target.random) {
                 return this.resolveAllMatchingRandomly(fieldResolution.targets, target, controllers);
             }
-            /*
-             * For all-matching without random, we need to gather energy from all matching creatures
-             * This is complex - for now, we'll require selection
-             */
-            const energyOptions: EnergyOption[] = [];
-            
+            // Non-random all-matching: collect all matching energy from every creature, up to count total
+            const results: Array<{ playerId: number; fieldIndex: number; energy: Partial<Record<AttachableEnergyType, number>> }> = [];
+            let remaining = target.count;
+
             for (const fieldTarget of fieldResolution.targets) {
+                if (remaining <= 0) {
+                    break; 
+                }
                 const creature = controllers.field.getRawCardByPosition(fieldTarget.playerId, fieldTarget.fieldIndex);
                 if (!creature) {
-                    continue;
+                    continue; 
                 }
 
                 const instanceId = getCurrentInstanceId(creature);
@@ -198,21 +199,17 @@ export class EnergyTargetResolver {
                 const availableEnergy = this.filterEnergyByCriteria(attachedEnergy, target.criteria);
 
                 if (this.getTotalEnergy(availableEnergy) > 0) {
-                    const cardData = controllers.cardRepository.getCreature(creature.templateId);
-                    energyOptions.push({
-                        playerId: fieldTarget.playerId,
-                        fieldIndex: fieldTarget.fieldIndex,
-                        availableEnergy,
-                        displayName: cardData?.name || 'Unknown',
-                    });
+                    const selected = this.selectEnergy(availableEnergy, remaining);
+                    remaining -= this.getTotalEnergy(selected);
+                    results.push({ playerId: fieldTarget.playerId, fieldIndex: fieldTarget.fieldIndex, energy: selected });
                 }
             }
 
-            if (energyOptions.length === 0) {
+            if (results.length === 0) {
                 return { type: 'no-valid-targets' };
             }
 
-            return { type: 'requires-selection', availableTargets: energyOptions };
+            return { type: 'resolved-multi', targets: results };
         }
 
         return { type: 'no-valid-targets' };


### PR DESCRIPTION
EnergyTargetResolver's all-matching non-random path now returns a resolved-multi covering every matching creature up to the count limit, instead of falling through to player selection. EnergyTransferEffectHandler loops all resolved source targets so a single effect can sweep energy from multiple creatures in one invocation.