### PR TITLE
Fix EvolveResponseMessage ambiguous evolutionId to evolutionTemplateId

### DIFF
--- a/src/event-handler.ts
+++ b/src/event-handler.ts
@@ -619,7 +619,7 @@ export const eventHandler = buildEventHandler<Controllers, ResponseMessage>({
             validators: [
                 EventHandler.validate('Evolution card not in hand', (controllers: Controllers, source: number, message: EvolveResponseMessage) => {
                     const hand = controllers.hand.getHand(source);
-                    return !hand.some(card => card.templateId === message.evolutionId);
+                    return !hand.some(card => card.templateId === message.evolutionTemplateId);
                 }),
                 EventHandler.validate('Invalid evolution target', (controllers: Controllers, source: number, message: EvolveResponseMessage) => {
                     if (message.position === 0) {
@@ -655,11 +655,9 @@ export const eventHandler = buildEventHandler<Controllers, ResponseMessage>({
                     }
                     
                     if (targetCard) {
-                        const evolutionData = controllers.cardRepository.getCreature(message.evolutionId);
+                        const evolutionData = controllers.cardRepository.getCreature(message.evolutionTemplateId);
                         const currentData = controllers.cardRepository.getCreature(getCurrentTemplateId(targetCard));
-                        
                         const isValidEvolution = evolutionData.previousStageName === currentData.name;
-                        
                         return !isValidEvolution;
                     }
                     return true;
@@ -675,7 +673,7 @@ export const eventHandler = buildEventHandler<Controllers, ResponseMessage>({
             controllers.waiting.removePosition(sourceHandler);
             
             const hand = controllers.hand.getHand(sourceHandler);
-            const evolutionCardIndex = hand.findIndex(card => card.templateId === message.evolutionId);
+            const evolutionCardIndex = hand.findIndex(card => card.templateId === message.evolutionTemplateId);
             if (evolutionCardIndex === -1) {
                 return; 
             }
@@ -702,7 +700,7 @@ export const eventHandler = buildEventHandler<Controllers, ResponseMessage>({
                         controllers.effects.clearEffectsForInstance(fieldInstanceId);
                     }
                 }
-                controllers.field.evolveActiveCard(sourceHandler, message.evolutionId, evolutionInstanceId, turnNumber);
+                controllers.field.evolveActiveCard(sourceHandler, message.evolutionTemplateId, evolutionInstanceId, turnNumber);
                 
                 // Trigger on-play effects for the evolved creature (as evolution)
                 const evolvedCard = controllers.field.getCardByPosition(sourceHandler, 0);
@@ -733,7 +731,7 @@ export const eventHandler = buildEventHandler<Controllers, ResponseMessage>({
                         controllers.effects.clearEffectsForInstance(fieldInstanceId);
                     }
                 }
-                controllers.field.evolveBenchedCard(sourceHandler, message.position - 1, message.evolutionId, evolutionInstanceId, turnNumber);
+                controllers.field.evolveBenchedCard(sourceHandler, message.position - 1, message.evolutionTemplateId, evolutionInstanceId, turnNumber);
                 
                 // Trigger on-play effects for the evolved creature (as evolution)
                 const benchCards = controllers.field.getCards(sourceHandler);
@@ -752,7 +750,7 @@ export const eventHandler = buildEventHandler<Controllers, ResponseMessage>({
                 }
             }
             
-            const { name } = controllers.cardRepository.getCreature(message.evolutionId);
+            const { name } = controllers.cardRepository.getCreature(message.evolutionTemplateId);
             controllers.players.messageAll(new EvolutionMessage(
                 'Previous Form',
                 name,

--- a/src/handlers/intermediary-handler-helpers.ts
+++ b/src/handlers/intermediary-handler-helpers.ts
@@ -390,12 +390,12 @@ export async function handleEvolve(cardRepository: CardRepository, intermediary:
                 if (position === 0) { // Active FieldCard
                     fieldCardOptions.push({
                         name: `${currentData?.name} → ${evolutionData?.name} (Active)`,
-                        value: { evolutionId: evolution, isActive: true },
+                        value: { evolutionTemplateId: evolution, isActive: true },
                     });
                 } else { // Bench FieldCard
                     fieldCardOptions.push({
                         name: `${currentData?.name} → ${evolutionData?.name} (Bench)`,
-                        value: { evolutionId: evolution, isActive: false, benchIndex: position - 1 },
+                        value: { evolutionTemplateId: evolution, isActive: false, benchIndex: position - 1 },
                     });
                 }
             }
@@ -416,7 +416,7 @@ export async function handleEvolve(cardRepository: CardRepository, intermediary:
         choices: fieldCardOptions,
     });
     
-    const selection = (await received)[0] as { evolutionId: string; isActive: boolean; benchIndex?: number } | null;
+    const selection = (await received)[0] as { evolutionTemplateId: string; isActive: boolean; benchIndex?: number } | null;
     
     if (!selection) {
         await handleAction(cardRepository, intermediary, handlerData, responsesQueue);
@@ -426,7 +426,7 @@ export async function handleEvolve(cardRepository: CardRepository, intermediary:
     // Calculate position: 0 for active, 1+ for bench
     const position = selection.isActive ? 0 : (selection.benchIndex! + 1);
     
-    responsesQueue.push(new EvolveResponseMessage(selection.evolutionId, position));
+    responsesQueue.push(new EvolveResponseMessage(selection.evolutionTemplateId, position));
 }
 
 /**

--- a/src/messages/response/evolve-response-message.ts
+++ b/src/messages/response/evolve-response-message.ts
@@ -4,9 +4,9 @@ export class EvolveResponseMessage extends Message {
     readonly type = 'evolve-response';
 
     constructor(
-        public readonly evolutionId: string,
+        public readonly evolutionTemplateId: string,
         public readonly position: number, // 0 = active, 1-3 = bench positions
     ) {
-        super([ `Evolving creature at position ${position} to ${evolutionId}` ]);
+        super([ `Evolving creature at position ${position} to ${evolutionTemplateId}` ]);
     }
 }


### PR DESCRIPTION
Aligns with all other response messages that use templateId to identify cards from hand (PlayCardResponseMessage, SelectCardResponseMessage).