### PR TITLE
Prevent abilities that would do nothing from being used

### DIFF
--- a/src/effects/action-validator.ts
+++ b/src/effects/action-validator.ts
@@ -2,7 +2,7 @@ import { HandlerData } from '../game-handler.js';
 import { CardRepository } from '../repository/card-repository.js';
 import { EnergyController, AttachableEnergyType } from '../controllers/energy-controller.js';
 import { StatusEffect } from '../controllers/status-effect-controller.js';
-import { getCurrentTemplateId, getFieldInstanceId } from '../utils/field-card-utils.js';
+import { getCurrentTemplateId, getFieldInstanceId, getCurrentInstanceId } from '../utils/field-card-utils.js';
 import { EffectValidator } from './effect-validator.js';
 import { EffectContextFactory } from './effect-context.js';
 
@@ -269,11 +269,15 @@ export class ActionValidator {
         }
         
         const ability = creatureData.ability;
-        
+
         if (ability.effects && ability.effects.length > 0) {
-            return EffectValidator.canApplyCardEffects(ability.effects, handlerData, playerId, `${creatureData.name}'s ${ability.name}`, undefined, cardRepository);
+            const effectName = `${creatureData.name}'s ${ability.name}`;
+            const instanceId = getCurrentInstanceId(creature);
+            // Use an ability context so that 'source' position resolves correctly to this field position.
+            const context = EffectContextFactory.createAbilityContext(playerId, effectName, instanceId, position);
+            return ability.effects.some(effect => EffectValidator.canApplyEffect(effect, handlerData, context, cardRepository));
         }
-        
+
         return true;
     }
 }

--- a/src/event-handler.ts
+++ b/src/event-handler.ts
@@ -843,20 +843,24 @@ export const eventHandler = buildEventHandler<Controllers, ResponseMessage>({
                     const fieldCards = controllers.field.getPlayedCards(source);
                     const fieldCard = fieldCards[message.fieldCardPosition];
                     if (!fieldCard) {
-                        return false; 
+                        return false;
                     }
                     const cardData = controllers.cardRepository.getCreature(fieldCard.templateId);
                     const ability = cardData.ability;
                     if (!ability) {
-                        return false; 
+                        return false;
                     }
-                    
+
                     // Allow unlimited abilities to be used multiple times
                     if (ability.trigger?.unlimited) {
                         return false;
                     }
-                    
+
                     return controllers.turnState.hasAbilityBeenUsedThisTurn(fieldCard.instanceId, ability.name);
+                }),
+                EventHandler.validate('Cannot use ability - effects cannot be applied', (controllers: Controllers, source: number, message: UseAbilityResponseMessage) => {
+                    const handlerData = ControllerUtils.createPlayerView(controllers, source);
+                    return !ActionValidator.canUseAbility(handlerData, controllers.cardRepository.cardRepository, source, message.fieldCardPosition);
                 }),
             ],
             fallback: (controllers: Controllers, source: number, message: UseAbilityResponseMessage) => {


### PR DESCRIPTION
Before accepting an ability use action, check whether the ability's effects can actually be applied (e.g. try-then requires the attempt to succeed). This prevents abilities from being counted as validated when their prerequisite effects (such as discarding a fire energy) are unavailable.