### PR TITLE
Support player choice for energy source/destination and energy distribution

### DIFF
--- a/spec/effects/handlers/energy-transfer.spec.ts
+++ b/spec/effects/handlers/energy-transfer.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { PlayCardResponseMessage } from '../../../src/messages/response/play-card-response-message.js';
 import { SelectTargetResponseMessage } from '../../../src/messages/response/select-target-response-message.js';
+import { SelectEnergyResponseMessage } from '../../../src/messages/response/select-energy-response-message.js';
 import { StateBuilder } from '../../helpers/state-builder.js';
 import { runTestGame } from '../../helpers/test-helpers.js';
 import { MockCardRepository } from '../../mock-repository.js';
@@ -191,6 +192,20 @@ describe('Energy Transfer Effect', () => {
                     target: { type: 'single-choice', chooser: 'self', criteria: { player: 'self', location: 'field', position: 'bench' }},
                 }],
             },
+            'multi-target-transfer-supporter': {
+                templateId: 'multi-target-transfer-supporter',
+                name: 'Multi Target Transfer Supporter',
+                effects: [{
+                    type: 'energy-transfer',
+                    source: {
+                        type: 'field',
+                        fieldTarget: { type: 'fixed', player: 'self', position: 'active' },
+                        criteria: { energyTypes: [ 'lightning' ] },
+                        count: 2,
+                    },
+                    target: { type: 'multi-choice', chooser: 'self', criteria: { player: 'self', location: 'field', position: 'bench' }, count: 2 },
+                }],
+            },
         },
     });
 
@@ -284,8 +299,12 @@ describe('Energy Transfer Effect', () => {
     });
 
     it('should handle multiple energy types (any energy)', () => {
+        // 2 matching types present but only 1 requested: player must choose which type to take.
         const { state, getExecutedCount } = runTestGame({
-            actions: [ new PlayCardResponseMessage('any-energy-transfer-supporter', 'supporter') ],
+            actions: [
+                new PlayCardResponseMessage('any-energy-transfer-supporter', 'supporter'),
+                new SelectEnergyResponseMessage([{ playerId: 0, fieldIndex: 0, energyType: 'lightning' }]),
+            ],
             customRepository: testRepository,
             stateCustomizer: StateBuilder.combine(
                 StateBuilder.withCreatures(0, 'basic-creature', [ 'high-hp-creature' ]),
@@ -294,10 +313,9 @@ describe('Energy Transfer Effect', () => {
             ),
         });
 
-        expect(getExecutedCount()).to.equal(1, 'Should have executed any energy transfer supporter');
-        
+        expect(getExecutedCount()).to.equal(2, 'Should have executed any energy transfer supporter and the energy type choice');
+
         const energyState = state.energy;
-        // Should transfer the first available energy type from the effect's energyTypes array (lightning in this case)
         expect(energyState.attachedEnergyByInstance['basic-creature-0'].lightning).to.equal(0, 'Active should have no lightning energy remaining');
         expect(energyState.attachedEnergyByInstance['basic-creature-0'].psychic).to.equal(1, 'Active should keep psychic energy');
         expect(energyState.attachedEnergyByInstance['high-hp-creature-0-0'].lightning).to.equal(1, 'Bench should have gained 1 lightning energy');
@@ -319,6 +337,59 @@ describe('Energy Transfer Effect', () => {
         const energyState = state.energy;
         expect(energyState.attachedEnergyByInstance['basic-creature-0'].fire).to.equal(0, 'Active should have no fire energy remaining');
         expect(energyState.attachedEnergyByInstance['high-hp-creature-0-0'].fire).to.equal(1, 'Bench should have gained only 1 fire energy (capped)');
+    });
+
+    it('should move 1 energy each to 2 chosen benched creatures (multi-choice destination)', () => {
+        /*
+         * Deliberately 3 bench creatures (more than the 2 needed) so this remains a real choice -
+         * with exactly 2 available for count:2 the resolver now auto-resolves without prompting
+         * (see "auto-resolves without prompting..." below), which is correct but would make this
+         * particular test a no-op for the SelectTargetResponseMessage step.
+         */
+        const multiTargetTransferSupporter = { templateId: 'multi-target-transfer-supporter', type: 'supporter' as const };
+        const { state, getExecutedCount } = runTestGame({
+            actions: [
+                new PlayCardResponseMessage('multi-target-transfer-supporter', 'supporter'),
+                new SelectTargetResponseMessage([{ playerId: 0, fieldIndex: 1 }, { playerId: 0, fieldIndex: 2 }]),
+            ],
+            customRepository: testRepository,
+            stateCustomizer: StateBuilder.combine(
+                StateBuilder.withCreatures(0, 'basic-creature', [ 'high-hp-creature', 'high-hp-creature', 'high-hp-creature' ]),
+                StateBuilder.withHand(0, [ multiTargetTransferSupporter ]),
+                StateBuilder.withEnergy('basic-creature-0', { lightning: 2 }),
+                StateBuilder.withEnergy('high-hp-creature-0-2', {}),
+            ),
+        });
+
+        expect(getExecutedCount()).to.equal(2, 'Should have executed the supporter and the bench selection');
+
+        const energyState = state.energy;
+        expect(energyState.attachedEnergyByInstance['basic-creature-0'].lightning).to.equal(0, 'Active should have no lightning energy remaining');
+        expect(energyState.attachedEnergyByInstance['high-hp-creature-0-0'].lightning).to.equal(1, 'First bench creature should have gained 1 lightning energy');
+        expect(energyState.attachedEnergyByInstance['high-hp-creature-0-1'].lightning).to.equal(1, 'Second bench creature should have gained 1 lightning energy');
+        expect(energyState.attachedEnergyByInstance['high-hp-creature-0-2'].lightning).to.equal(0, 'Unselected third bench creature should be untouched');
+    });
+
+    it('auto-resolves without prompting when exactly 2 benched creatures exist for a count:2 destination', () => {
+        const multiTargetTransferSupporter = { templateId: 'multi-target-transfer-supporter', type: 'supporter' as const };
+        const { state, getExecutedCount } = runTestGame({
+            actions: [
+                new PlayCardResponseMessage('multi-target-transfer-supporter', 'supporter'),
+            ],
+            customRepository: testRepository,
+            stateCustomizer: StateBuilder.combine(
+                StateBuilder.withCreatures(0, 'basic-creature', [ 'high-hp-creature', 'high-hp-creature' ]),
+                StateBuilder.withHand(0, [ multiTargetTransferSupporter ]),
+                StateBuilder.withEnergy('basic-creature-0', { lightning: 2 }),
+            ),
+        });
+
+        expect(getExecutedCount()).to.equal(1, 'No real choice with exactly 2 valid targets for count:2 - should auto-resolve');
+
+        const energyState = state.energy;
+        expect(energyState.attachedEnergyByInstance['basic-creature-0'].lightning).to.equal(0);
+        expect(energyState.attachedEnergyByInstance['high-hp-creature-0-0'].lightning).to.equal(1);
+        expect(energyState.attachedEnergyByInstance['high-hp-creature-0-1'].lightning).to.equal(1);
     });
 
     it('should fail when source has no required energy type', () => {
@@ -489,5 +560,161 @@ describe('Energy Discard with Energy Targets', () => {
              * - target: field target (active) + energy filter (psychic, dark) + count (1 each)
              */
         });
+    });
+});
+
+describe('Energy Transfer from Discard Pile', () => {
+    const discardTestRepository = new MockCardRepository({
+        creatures: {
+            'basic-creature': {
+                templateId: 'basic-creature',
+                name: 'Basic Creature',
+                maxHp: 80,
+                type: 'fire',
+                weakness: 'water',
+                retreatCost: 1,
+                attacks: [{ name: 'Basic Attack', damage: 20, energyRequirements: [{ type: 'fire', amount: 1 }] }],
+            },
+        },
+        supporters: {
+            'discard-energy-supporter': {
+                templateId: 'discard-energy-supporter',
+                name: 'Discard Energy Supporter',
+                effects: [{
+                    type: 'energy-transfer',
+                    source: { type: 'discard', count: 1 },
+                    target: { type: 'fixed', player: 'self', position: 'active' },
+                }],
+            },
+        },
+    });
+    const discardEnergySupporter = { templateId: 'discard-energy-supporter', type: 'supporter' as const };
+
+    it('should auto-resolve and attach energy from discard when only one type is present', () => {
+        const { state, getExecutedCount } = runTestGame({
+            actions: [ new PlayCardResponseMessage('discard-energy-supporter', 'supporter') ],
+            customRepository: discardTestRepository,
+            stateCustomizer: StateBuilder.combine(
+                StateBuilder.withCreatures(0, 'basic-creature'),
+                StateBuilder.withHand(0, [ discardEnergySupporter ]),
+                StateBuilder.withDiscardedEnergy(0, { fire: 2 }),
+            ),
+        });
+
+        expect(getExecutedCount()).to.equal(1, 'Should have executed without needing a type choice');
+
+        const energyState = state.energy;
+        expect(energyState.attachedEnergyByInstance['basic-creature-0'].fire).to.equal(1, 'Active should have gained 1 fire energy');
+        expect(energyState.discardedEnergy[0].fire).to.equal(1, 'Discard pile should have 1 fire energy remaining');
+    });
+
+    it('should prompt for a type choice when the discard pile has multiple matching types (Dragonair-style)', () => {
+        const { state, getExecutedCount } = runTestGame({
+            actions: [
+                new PlayCardResponseMessage('discard-energy-supporter', 'supporter'),
+                new SelectEnergyResponseMessage([{ playerId: 0, fieldIndex: -1, energyType: 'water' }]),
+            ],
+            customRepository: discardTestRepository,
+            stateCustomizer: StateBuilder.combine(
+                StateBuilder.withCreatures(0, 'basic-creature'),
+                StateBuilder.withHand(0, [ discardEnergySupporter ]),
+                StateBuilder.withDiscardedEnergy(0, { fire: 1, water: 1 }),
+            ),
+        });
+
+        expect(getExecutedCount()).to.equal(2, 'Should have executed the supporter and the energy type choice');
+
+        const energyState = state.energy;
+        expect(energyState.attachedEnergyByInstance['basic-creature-0'].water).to.equal(1, 'Active should have gained 1 water energy');
+        expect(energyState.attachedEnergyByInstance['basic-creature-0'].fire ?? 0).to.equal(0, 'Active should not have gained fire energy');
+        expect(energyState.discardedEnergy[0].water).to.equal(0, 'Discard pile should have no water energy remaining');
+        expect(energyState.discardedEnergy[0].fire).to.equal(1, 'Discard pile should still have 1 fire energy');
+    });
+});
+
+describe('Energy Transfer from a Benched Creature of Choice', () => {
+    const benchChoiceRepository = new MockCardRepository({
+        creatures: {
+            'basic-creature': {
+                templateId: 'basic-creature',
+                name: 'Basic Creature',
+                maxHp: 80,
+                type: 'fire',
+                weakness: 'water',
+                retreatCost: 1,
+                attacks: [{ name: 'Basic Attack', damage: 20, energyRequirements: [{ type: 'fire', amount: 1 }] }],
+            },
+            'high-hp-creature': {
+                templateId: 'high-hp-creature',
+                name: 'High HP Creature',
+                maxHp: 140,
+                type: 'water',
+                weakness: 'grass',
+                retreatCost: 2,
+                attacks: [{ name: 'Water Attack', damage: 30, energyRequirements: [{ type: 'water', amount: 2 }] }],
+            },
+        },
+        supporters: {
+            'bench-energy-transfer-supporter': {
+                templateId: 'bench-energy-transfer-supporter',
+                name: 'Bench Energy Transfer Supporter',
+                effects: [{
+                    type: 'energy-transfer',
+                    source: {
+                        type: 'field',
+                        fieldTarget: { type: 'single-choice', chooser: 'self', criteria: { player: 'self', location: 'field', position: 'bench' }},
+                        criteria: { energyTypes: [ 'fire', 'water' ] },
+                        count: 1,
+                    },
+                    target: { type: 'fixed', player: 'self', position: 'active' },
+                }],
+            },
+        },
+    });
+    const benchEnergyTransferSupporter = { templateId: 'bench-energy-transfer-supporter', type: 'supporter' as const };
+
+    it('should prompt for which benched creature when multiple qualify (unaffected by the type-choice fix)', () => {
+        const { state, getExecutedCount } = runTestGame({
+            actions: [
+                new PlayCardResponseMessage('bench-energy-transfer-supporter', 'supporter'),
+                new SelectEnergyResponseMessage([{ playerId: 0, fieldIndex: 2 }]),
+            ],
+            customRepository: benchChoiceRepository,
+            stateCustomizer: StateBuilder.combine(
+                StateBuilder.withCreatures(0, 'basic-creature', [ 'basic-creature', 'high-hp-creature' ]),
+                StateBuilder.withHand(0, [ benchEnergyTransferSupporter ]),
+                StateBuilder.withEnergy('basic-creature-0-0', { fire: 1 }),
+                StateBuilder.withEnergy('high-hp-creature-0-1', { water: 1 }),
+            ),
+        });
+
+        expect(getExecutedCount()).to.equal(2, 'Should have executed the supporter and the bench creature choice');
+
+        const energyState = state.energy;
+        expect(energyState.attachedEnergyByInstance['high-hp-creature-0-1'].water).to.equal(0, 'Chosen bench creature should have given up its water energy');
+        expect(energyState.attachedEnergyByInstance['basic-creature-0'].water).to.equal(1, 'Active should have gained 1 water energy');
+        expect(energyState.attachedEnergyByInstance['basic-creature-0-0'].fire).to.equal(1, 'Other bench creature should be untouched');
+    });
+
+    it('should prompt for an energy TYPE when the sole qualifying benched creature holds 2+ matching types', () => {
+        const { state, getExecutedCount } = runTestGame({
+            actions: [
+                new PlayCardResponseMessage('bench-energy-transfer-supporter', 'supporter'),
+                new SelectEnergyResponseMessage([{ playerId: 0, fieldIndex: 1, energyType: 'water' }]),
+            ],
+            customRepository: benchChoiceRepository,
+            stateCustomizer: StateBuilder.combine(
+                StateBuilder.withCreatures(0, 'basic-creature', [ 'high-hp-creature' ]),
+                StateBuilder.withHand(0, [ benchEnergyTransferSupporter ]),
+                StateBuilder.withEnergy('high-hp-creature-0-0', { fire: 1, water: 1 }),
+            ),
+        });
+
+        expect(getExecutedCount()).to.equal(2, 'Should have executed the supporter and the energy type choice');
+
+        const energyState = state.energy;
+        expect(energyState.attachedEnergyByInstance['basic-creature-0'].water).to.equal(1, 'Active should have gained 1 water energy');
+        expect(energyState.attachedEnergyByInstance['high-hp-creature-0-0'].water).to.equal(0, 'Bench creature should have given up its water energy');
+        expect(energyState.attachedEnergyByInstance['high-hp-creature-0-0'].fire).to.equal(1, 'Bench creature should keep its fire energy');
     });
 });

--- a/spec/effects/handlers/energy.spec.ts
+++ b/spec/effects/handlers/energy.spec.ts
@@ -3,6 +3,7 @@ import { runTestGame } from '../../helpers/test-helpers.js';
 import { StateBuilder } from '../../helpers/state-builder.js';
 import { PlayCardResponseMessage } from '../../../src/messages/response/play-card-response-message.js';
 import { AttackResponseMessage } from '../../../src/messages/response/attack-response-message.js';
+import { SelectTargetResponseMessage } from '../../../src/messages/response/select-target-response-message.js';
 import { MockCardRepository } from '../../mock-repository.js';
 import { EnergyDictionary, EnergyState } from '../../../src/controllers/energy-controller.js';
 import { EnergyAttachEffectHandler } from '../../../src/effects/handlers/energy-attach-effect-handler.js';
@@ -14,6 +15,90 @@ import { HandlerDataBuilder } from '../../helpers/handler-data-builder.js';
 function getTotalEnergy(energyDict: EnergyDictionary): number {
     return Object.values(energyDict).reduce((sum, count) => sum + count, 0);
 }
+
+/*
+ * "Take 3 Psychic Energy ... attach it to your Psychic Pokemon in any way you like" (Card A) needs a
+ * *single* decision distributing 3 interchangeable units across chosen targets, including stacking
+ * all of them on one creature - this is the `multi-choice` + `allowRepeats` target.
+ *
+ * "Take a Fire, Water, and Lightning Energy ... attach them to your Benched Pokemon in any way you
+ * like" (Card B) has no interchangeable units (each is a distinct type), so it needs no new mechanism:
+ * three ordinary sequential `energy-attach` effects, each with its own `single-choice` target.
+ */
+const distributionTestRepository = new MockCardRepository({
+    creatures: {
+        'psychic-creature': {
+            templateId: 'psychic-creature',
+            name: 'Psychic Creature',
+            maxHp: 80,
+            type: 'psychic',
+            weakness: 'darkness',
+            retreatCost: 1,
+            attacks: [{ name: 'Psy Attack', damage: 20, energyRequirements: [{ type: 'psychic', amount: 1 }] }],
+        },
+        'basic-creature-distribution': {
+            templateId: 'basic-creature-distribution',
+            name: 'Basic Creature',
+            maxHp: 80,
+            type: 'fire',
+            weakness: 'water',
+            retreatCost: 1,
+            attacks: [{ name: 'Basic Attack', damage: 20, energyRequirements: [{ type: 'fire', amount: 1 }] }],
+        },
+    },
+    supporters: {
+        'distribute-psychic-supporter': {
+            templateId: 'distribute-psychic-supporter',
+            name: 'Distribute Psychic Supporter',
+            effects: [{
+                type: 'energy-attach',
+                energyType: 'psychic',
+                amount: { type: 'constant', value: 1 },
+                target: {
+                    type: 'multi-choice',
+                    chooser: 'self',
+                    criteria: { player: 'self', location: 'field', fieldCriteria: { cardCriteria: { isType: 'psychic' }}},
+                    count: 3,
+                    allowRepeats: true,
+                },
+            }],
+        },
+        'triple-type-supporter': {
+            templateId: 'triple-type-supporter',
+            name: 'Triple Type Supporter',
+            effects: [
+                {
+                    type: 'energy-attach',
+                    energyType: 'fire',
+                    amount: { type: 'constant', value: 1 },
+                    target: { type: 'single-choice', chooser: 'self', criteria: { player: 'self', location: 'field', position: 'bench' }},
+                },
+                {
+                    type: 'energy-attach',
+                    energyType: 'water',
+                    amount: { type: 'constant', value: 1 },
+                    target: { type: 'single-choice', chooser: 'self', criteria: { player: 'self', location: 'field', position: 'bench' }},
+                },
+                {
+                    type: 'energy-attach',
+                    energyType: 'lightning',
+                    amount: { type: 'constant', value: 1 },
+                    target: { type: 'single-choice', chooser: 'self', criteria: { player: 'self', location: 'field', position: 'bench' }},
+                },
+            ],
+        },
+        'attach-two-bench-supporter': {
+            templateId: 'attach-two-bench-supporter',
+            name: 'Attach Two Bench Supporter',
+            effects: [{
+                type: 'energy-attach',
+                energyType: 'fire',
+                amount: { type: 'constant', value: 1 },
+                target: { type: 'multi-choice', chooser: 'self', criteria: { player: 'self', location: 'field', position: 'bench' }, count: 2 },
+            }],
+        },
+    },
+});
 
 describe('Energy Effect', () => {
     describe('canApply', () => {
@@ -460,6 +545,238 @@ describe('Energy Effect', () => {
             const benchEnergy = state.energy.attachedEnergyByInstance['energy-holder-0-0'];
             expect(activeEnergy?.fire ?? 0).to.equal(0, 'fire discarded from active');
             expect(benchEnergy?.water ?? 0).to.equal(0, 'water discarded from bench');
+        });
+    });
+
+    describe('Energy Distribution (allowRepeats multi-choice)', () => {
+        const psychicSupporter = { templateId: 'distribute-psychic-supporter', type: 'supporter' as const };
+        const tripleTypeSupporter = { templateId: 'triple-type-supporter', type: 'supporter' as const };
+
+        describe('Card A - distribute 3 interchangeable energy in one selection', () => {
+            it('stacks all 3 units on a single chosen creature', () => {
+                const { state, getExecutedCount } = runTestGame({
+                    actions: [
+                        new PlayCardResponseMessage('distribute-psychic-supporter', 'supporter'),
+                        new SelectTargetResponseMessage([
+                            { playerId: 0, fieldIndex: 0 },
+                            { playerId: 0, fieldIndex: 0 },
+                            { playerId: 0, fieldIndex: 0 },
+                        ]),
+                    ],
+                    customRepository: distributionTestRepository,
+                    stateCustomizer: StateBuilder.combine(
+                        StateBuilder.withCreatures(0, 'psychic-creature', [ 'psychic-creature', 'psychic-creature' ]),
+                        StateBuilder.withHand(0, [ psychicSupporter ]),
+                        StateBuilder.withEnergy('psychic-creature-0-0', {}),
+                        StateBuilder.withEnergy('psychic-creature-0-1', {}),
+                    ),
+                });
+
+                expect(getExecutedCount()).to.equal(2, 'Should have executed the supporter and the distribution selection');
+
+                const energyState = state.energy;
+                expect(energyState.attachedEnergyByInstance['psychic-creature-0'].psychic).to.equal(3, 'Active should have all 3 psychic energy');
+                expect(energyState.attachedEnergyByInstance['psychic-creature-0-0'].psychic).to.equal(0);
+                expect(energyState.attachedEnergyByInstance['psychic-creature-0-1'].psychic).to.equal(0);
+            });
+
+            it('splits 2-1 across two chosen creatures', () => {
+                const { state, getExecutedCount } = runTestGame({
+                    actions: [
+                        new PlayCardResponseMessage('distribute-psychic-supporter', 'supporter'),
+                        new SelectTargetResponseMessage([
+                            { playerId: 0, fieldIndex: 0 },
+                            { playerId: 0, fieldIndex: 0 },
+                            { playerId: 0, fieldIndex: 1 },
+                        ]),
+                    ],
+                    customRepository: distributionTestRepository,
+                    stateCustomizer: StateBuilder.combine(
+                        StateBuilder.withCreatures(0, 'psychic-creature', [ 'psychic-creature', 'psychic-creature' ]),
+                        StateBuilder.withHand(0, [ psychicSupporter ]),
+                        StateBuilder.withEnergy('psychic-creature-0-1', {}),
+                    ),
+                });
+
+                expect(getExecutedCount()).to.equal(2);
+
+                const energyState = state.energy;
+                expect(energyState.attachedEnergyByInstance['psychic-creature-0'].psychic).to.equal(2, 'Active should have gained 2 psychic energy');
+                expect(energyState.attachedEnergyByInstance['psychic-creature-0-0'].psychic).to.equal(1, 'First bench should have gained 1 psychic energy');
+                expect(energyState.attachedEnergyByInstance['psychic-creature-0-1'].psychic).to.equal(0);
+            });
+
+            it('splits 1-1-1 across three distinct chosen creatures', () => {
+                const { state, getExecutedCount } = runTestGame({
+                    actions: [
+                        new PlayCardResponseMessage('distribute-psychic-supporter', 'supporter'),
+                        new SelectTargetResponseMessage([
+                            { playerId: 0, fieldIndex: 0 },
+                            { playerId: 0, fieldIndex: 1 },
+                            { playerId: 0, fieldIndex: 2 },
+                        ]),
+                    ],
+                    customRepository: distributionTestRepository,
+                    stateCustomizer: StateBuilder.combine(
+                        StateBuilder.withCreatures(0, 'psychic-creature', [ 'psychic-creature', 'psychic-creature' ]),
+                        StateBuilder.withHand(0, [ psychicSupporter ]),
+                    ),
+                });
+
+                expect(getExecutedCount()).to.equal(2);
+
+                const energyState = state.energy;
+                expect(energyState.attachedEnergyByInstance['psychic-creature-0'].psychic).to.equal(1);
+                expect(energyState.attachedEnergyByInstance['psychic-creature-0-0'].psychic).to.equal(1);
+                expect(energyState.attachedEnergyByInstance['psychic-creature-0-1'].psychic).to.equal(1);
+            });
+
+            it('auto-resolves without prompting when only one Psychic Pokemon is in play', () => {
+                const { state, getExecutedCount } = runTestGame({
+                    actions: [
+                        new PlayCardResponseMessage('distribute-psychic-supporter', 'supporter'),
+                    ],
+                    customRepository: distributionTestRepository,
+                    stateCustomizer: StateBuilder.combine(
+                        StateBuilder.withCreatures(0, 'psychic-creature', [ 'basic-creature-distribution', 'basic-creature-distribution' ]),
+                        StateBuilder.withHand(0, [ psychicSupporter ]),
+                    ),
+                });
+
+                expect(getExecutedCount()).to.equal(1, 'Should auto-resolve without a separate selection action');
+
+                const energyState = state.energy;
+                expect(energyState.attachedEnergyByInstance['psychic-creature-0'].psychic).to.equal(3, 'The lone Psychic Pokemon should get all 3 units');
+            });
+
+            it('rejects a response with more than 3 targets or a target outside the available list', () => {
+                const { state, getExecutedCount } = runTestGame({
+                    actions: [
+                        new PlayCardResponseMessage('distribute-psychic-supporter', 'supporter'),
+                        new SelectTargetResponseMessage([
+                            { playerId: 0, fieldIndex: 5 },
+                            { playerId: 0, fieldIndex: 5 },
+                            { playerId: 0, fieldIndex: 5 },
+                        ]),
+                    ],
+                    customRepository: distributionTestRepository,
+                    stateCustomizer: StateBuilder.combine(
+                        StateBuilder.withCreatures(0, 'psychic-creature', [ 'psychic-creature', 'psychic-creature' ]),
+                        StateBuilder.withHand(0, [ psychicSupporter ]),
+                        StateBuilder.withEnergy('psychic-creature-0', {}),
+                    ),
+                });
+
+                // Invalid selection is discarded by the fallback; no energy should have been attached.
+                expect(getExecutedCount()).to.equal(1);
+                const energyState = state.energy;
+                expect(energyState.attachedEnergyByInstance['psychic-creature-0'].psychic).to.equal(0);
+            });
+        });
+
+        describe('Card B - three independent single-type picks (no new mechanism needed)', () => {
+            it('lets each of the 3 sequential picks target the same or different bench creatures', () => {
+                const { state, getExecutedCount } = runTestGame({
+                    actions: [
+                        new PlayCardResponseMessage('triple-type-supporter', 'supporter'),
+                        new SelectTargetResponseMessage([{ playerId: 0, fieldIndex: 1 }]), // fire
+                        new SelectTargetResponseMessage([{ playerId: 0, fieldIndex: 1 }]), // water -> same creature
+                        new SelectTargetResponseMessage([{ playerId: 0, fieldIndex: 2 }]), // lightning -> different creature
+                    ],
+                    customRepository: distributionTestRepository,
+                    stateCustomizer: StateBuilder.combine(
+                        StateBuilder.withCreatures(0, 'psychic-creature', [ 'basic-creature-distribution', 'basic-creature-distribution' ]),
+                        StateBuilder.withHand(0, [ tripleTypeSupporter ]),
+                    ),
+                });
+
+                expect(getExecutedCount()).to.equal(4, 'Should have executed the supporter and all 3 picks');
+
+                const energyState = state.energy;
+                expect(energyState.attachedEnergyByInstance['basic-creature-distribution-0-0'].fire).to.equal(1);
+                expect(energyState.attachedEnergyByInstance['basic-creature-distribution-0-0'].water).to.equal(1);
+                expect(energyState.attachedEnergyByInstance['basic-creature-distribution-0-1'].lightning).to.equal(1);
+            });
+        });
+    });
+
+    describe('Multi-choice auto-resolve when there is no real choice (general, not energy-specific)', () => {
+        it('auto-resolves without repeats when available options exactly equal the required count', () => {
+            const attachTwoBenchSupporter = { templateId: 'attach-two-bench-supporter', type: 'supporter' as const };
+            const { state, getExecutedCount } = runTestGame({
+                actions: [ new PlayCardResponseMessage('attach-two-bench-supporter', 'supporter') ],
+                customRepository: distributionTestRepository,
+                stateCustomizer: StateBuilder.combine(
+                    StateBuilder.withCreatures(0, 'basic-creature-distribution', [ 'basic-creature-distribution', 'basic-creature-distribution' ]), // exactly 2 bench
+                    StateBuilder.withHand(0, [ attachTwoBenchSupporter ]),
+                ),
+            });
+
+            expect(getExecutedCount()).to.equal(1, 'Should auto-resolve without a separate selection action');
+            const energyState = state.energy;
+            expect(energyState.attachedEnergyByInstance['basic-creature-distribution-0-0'].fire).to.equal(1);
+            expect(energyState.attachedEnergyByInstance['basic-creature-distribution-0-1'].fire).to.equal(1);
+        });
+
+        it('still requires an explicit selection without repeats when there are more options than needed', () => {
+            const attachTwoBenchSupporter = { templateId: 'attach-two-bench-supporter', type: 'supporter' as const };
+            const { state, getExecutedCount } = runTestGame({
+                actions: [
+                    new PlayCardResponseMessage('attach-two-bench-supporter', 'supporter'),
+                    new SelectTargetResponseMessage([{ playerId: 0, fieldIndex: 1 }, { playerId: 0, fieldIndex: 2 }]),
+                ],
+                customRepository: distributionTestRepository,
+                stateCustomizer: StateBuilder.combine(
+                    StateBuilder.withCreatures(0, 'basic-creature-distribution', [ 'basic-creature-distribution', 'basic-creature-distribution', 'basic-creature-distribution' ]), // 3 bench, need 2
+                    StateBuilder.withHand(0, [ attachTwoBenchSupporter ]),
+                    StateBuilder.withEnergy('basic-creature-distribution-0-2', {}),
+                ),
+            });
+
+            expect(getExecutedCount()).to.equal(2, 'Should have executed the supporter and the bench selection');
+            const energyState = state.energy;
+            expect(energyState.attachedEnergyByInstance['basic-creature-distribution-0-0'].fire).to.equal(1);
+            expect(energyState.attachedEnergyByInstance['basic-creature-distribution-0-1'].fire).to.equal(1);
+            expect(energyState.attachedEnergyByInstance['basic-creature-distribution-0-2'].fire).to.equal(0);
+        });
+
+        it('does not crash and applies to no one without repeats when there are fewer options than needed', () => {
+            const attachTwoBenchSupporter = { templateId: 'attach-two-bench-supporter', type: 'supporter' as const };
+            const { state, getExecutedCount } = runTestGame({
+                actions: [ new PlayCardResponseMessage('attach-two-bench-supporter', 'supporter') ],
+                customRepository: distributionTestRepository,
+                stateCustomizer: StateBuilder.combine(
+                    StateBuilder.withCreatures(0, 'basic-creature-distribution', [ 'basic-creature-distribution' ]), // only 1 bench, need 2
+                    StateBuilder.withHand(0, [ attachTwoBenchSupporter ]),
+                    StateBuilder.withEnergy('basic-creature-distribution-0-0', {}),
+                ),
+            });
+
+            expect(getExecutedCount()).to.equal(1, 'Supporter still resolves (as a no-op for the attach effect)');
+            const energyState = state.energy;
+            expect(energyState.attachedEnergyByInstance['basic-creature-distribution-0-0'].fire).to.equal(0);
+        });
+    });
+
+    describe('Regression: multi-choice without allowRepeats still rejects duplicate targets', () => {
+        it('discards a response that selects the same bench creature twice', () => {
+            const attachTwoBenchSupporter = { templateId: 'attach-two-bench-supporter', type: 'supporter' as const };
+            const { state, getExecutedCount } = runTestGame({
+                actions: [
+                    new PlayCardResponseMessage('attach-two-bench-supporter', 'supporter'),
+                    new SelectTargetResponseMessage([{ playerId: 0, fieldIndex: 1 }, { playerId: 0, fieldIndex: 1 }]),
+                ],
+                customRepository: distributionTestRepository,
+                stateCustomizer: StateBuilder.combine(
+                    StateBuilder.withCreatures(0, 'basic-creature-distribution', [ 'basic-creature-distribution', 'basic-creature-distribution', 'basic-creature-distribution' ]),
+                    StateBuilder.withHand(0, [ attachTwoBenchSupporter ]),
+                    StateBuilder.withEnergy('basic-creature-distribution-0-0', {}),
+                ),
+            });
+
+            expect(getExecutedCount()).to.equal(1, 'The duplicate selection is invalid and discarded by the fallback');
+            const energyState = state.energy;
+            expect(energyState.attachedEnergyByInstance['basic-creature-distribution-0-0'].fire).to.equal(0);
         });
     });
 });

--- a/spec/helpers/state-builder.ts
+++ b/spec/helpers/state-builder.ts
@@ -323,6 +323,12 @@ export class StateBuilder {
         };
     }
 
+    static withDiscardedEnergy(player: number, energyTypes: PartialEnergyDict) {
+        return (state: ControllerState<Controllers>) => {
+            state.energy.discardedEnergy[player] = { ...createEmptyEnergyDict(), ...energyTypes };
+        };
+    }
+
     static withNoEnergy(player: number) {
         return (state: ControllerState<Controllers>) => {
             // Set current energy to null (no energy available)

--- a/src/effects/effect-applier.ts
+++ b/src/effects/effect-applier.ts
@@ -1,8 +1,8 @@
 import { Controllers } from '../controllers/controllers.js';
 import { HandlerData } from '../game-handler.js';
 import { Effect } from '../repository/effect-types.js';
-import { ResolvedFieldTarget } from '../repository/targets/field-target.js';
-import { EnergyTarget } from '../repository/targets/energy-target.js';
+import { FieldTarget, ResolvedFieldTarget, SingleFieldTarget } from '../repository/targets/field-target.js';
+import { AttachableEnergyType } from '../repository/energy-types.js';
 import { ControllerUtils } from '../utils/controller-utils.js';
 import { CardRepository } from '../repository/card-repository.js';
 import { GameCard } from '../controllers/card-types.js';
@@ -53,7 +53,16 @@ export class EffectApplier {
                 continue;
             }
 
-            const continuationEffects = effect.type === 'choice-delegation' && effectIndex < effects.length - 1
+            /*
+             * If this effect pauses on a player selection (e.g. its target needs a choice), the
+             * remaining effects in this list must ride along as continuationEffects so they resume
+             * after the selection resolves - otherwise the natural for-loop below never reaches them,
+             * since a pause returns out of this function entirely. Harmless to compute unconditionally:
+             * it's only ever consumed at the point a pending selection is actually created (see the
+             * `context.selectionContinuationEffects` reads across effect-applier.ts/field-target-resolver.ts),
+             * so effects that resolve immediately are unaffected - the for-loop just continues as before.
+             */
+            const continuationEffects = effectIndex < effects.length - 1
                 ? effects.slice(effectIndex + 1)
                 : undefined;
 
@@ -111,13 +120,13 @@ export class EffectApplier {
             let resolvedTarget: ResolvedFieldTarget | ResolvedMultiEnergyTarget | undefined;
             
             /*
-             * Check if this is an EnergyTarget (has fieldTarget, count, and type='field') or FieldTarget
-             * EnergyTarget has a 'count' property that FieldTarget doesn't have
+             * Check if this is an EnergyTarget (type 'field' or 'discard') or a FieldTarget.
+             * EnergyTarget's 'field'/'discard' discriminants never collide with FieldTarget's.
              */
-            if (target && typeof target === 'object' && 'fieldTarget' in target && 'count' in target) {
+            if (target && typeof target === 'object' && isEnergyResolutionTarget(target)) {
                 // This is an EnergyTarget - use EnergyTargetResolver
-                const energyTarget = target as unknown as EnergyTarget;
-                
+                const energyTarget = target;
+
                 /*
                  * Check if selection is needed (EnergyTargetResolver handles inner fieldTarget resolution)
                  * TODO: Implement handleTargetSelection for EnergyTargetResolver if needed
@@ -152,9 +161,11 @@ export class EffectApplier {
             } else {
                 /*
                  * This is a FieldTarget - use FieldTargetResolver
-                 * Check if this target needs selection
+                 * Check if this target needs selection. Pass resolvedEffect (not the raw effect) so
+                 * that any earlier requirement already resolved in this loop (e.g. a source that
+                 * auto-resolved before this destination needed a player choice) isn't discarded.
                  */
-                if (FieldTargetResolver.handleTargetSelection(controllers, effect, context, target)) {
+                if (FieldTargetResolver.handleTargetSelection(controllers, resolvedEffect, context, target)) {
                     return null; // Pending selection
                 }
                 
@@ -280,7 +291,7 @@ export class EffectApplier {
      * @param targetPlayerId The selected target player ID
      * @param targetCreatureIndex The selected target creature index
      */
-    static resumeEffectWithSelection(controllers: Controllers, pendingSelection: PendingFieldSelection, targetPlayerId: number, targetCreatureIndex: number): boolean {
+    static resumeEffectWithSelection(controllers: Controllers, pendingSelection: PendingFieldSelection, selectedTargets: Array<{ playerId: number; fieldIndex: number }>): boolean {
         const { effect, originalContext, selectionType: _selectionType = 'target' } = pendingSelection;
         const context = pendingSelection.continuationEffects && pendingSelection.continuationEffects.length > 0
             ? { ...originalContext, selectionContinuationEffects: pendingSelection.continuationEffects }
@@ -290,14 +301,11 @@ export class EffectApplier {
          * Target validation is now handled at the event handler level
          * If we reach here, the target is valid
          */
-        
-        // Create a resolved target from the selection
+
+        // Create a resolved target from the selection (may contain multiple targets for multi-choice selections)
         const resolvedTarget = {
             type: 'resolved' as const,
-            targets: [{
-                playerId: targetPlayerId,
-                fieldIndex: targetCreatureIndex,
-            }],
+            targets: selectedTargets,
         };
         
         /*
@@ -366,8 +374,9 @@ export class EffectApplier {
                     effect: resolvedEffect,
                     originalContext,
                     continuationEffects: originalContext.selectionContinuationEffects,
-                    count: 1,
+                    count: target.type === 'multi-choice' ? target.count : 1,
                     availableTargets: nextAvailableTargets,
+                    allowRepeats: target.type === 'multi-choice' ? target.allowRepeats : undefined,
                 };
                 controllers.turnState.setPendingSelection(pendingSelection);
                 return true; // Indicate that a new pending selection was set up
@@ -455,7 +464,7 @@ export class EffectApplier {
         // Check if any target requires selection
         for (const requirement of requirements) {
             const innerTarget = isEnergyResolutionTarget(requirement.target)
-                ? requirement.target.fieldTarget
+                ? (requirement.target.type === 'field' ? requirement.target.fieldTarget : undefined)
                 : requirement.target;
             if (FieldTargetResolver.requiresTargetSelection(innerTarget, context)) {
                 return true;
@@ -521,7 +530,7 @@ export class EffectApplier {
     static resumeEffectWithEnergySelection(
         controllers: Controllers,
         pendingSelection: PendingEnergySelection,
-        selectedTargets: Array<{ playerId: number; fieldIndex: number }>,
+        selectedTargets: Array<{ playerId: number; fieldIndex: number; energyType?: AttachableEnergyType }>,
     ): void {
         const { effect, originalContext, availableEnergy } = pendingSelection;
         const context = pendingSelection.continuationEffects && pendingSelection.continuationEffects.length > 0
@@ -534,13 +543,17 @@ export class EffectApplier {
             return;
         }
 
-        // Build ResolvedMultiEnergyTarget from the selected EnergyOptions
+        // Build ResolvedMultiEnergyTarget from the selected EnergyOptions.
+        // Options are matched by (playerId, fieldIndex, energyType) since type-choice options
+        // (e.g. picking which energy type to take from the discard pile) can share the same
+        // playerId/fieldIndex and differ only by energyType.
         const resolvedTargets = selectedTargets
-            .map(sel => availableEnergy.find(opt => opt.playerId === sel.playerId && opt.fieldIndex === sel.fieldIndex))
+            .map(sel => availableEnergy.find(opt => opt.playerId === sel.playerId && opt.fieldIndex === sel.fieldIndex && opt.energyType === sel.energyType))
             .filter((opt): opt is EnergyOption => opt !== undefined)
             .map(opt => ({
                 playerId: opt.playerId,
                 fieldIndex: opt.fieldIndex,
+                location: opt.location,
                 energy: opt.availableEnergy,
             }));
 
@@ -556,15 +569,57 @@ export class EffectApplier {
          * Deep copy the effect to avoid modifying the original
          */
         let resolvedEffect = JSON.parse(JSON.stringify(effect));
+        // Set when another requirement (e.g. the destination field target) also needs player input;
+        // resolution is deferred to a follow-up PendingFieldSelection instead of applying immediately.
+        let pendingFieldRequirement: { targetProperty: string; target: FieldTarget } | undefined;
+
         for (const requirement of requirements) {
             const target = requirement.target;
-            if (target && typeof target === 'object' && 'fieldTarget' in target && 'count' in target) {
+            if (target && typeof target === 'object' && ((target as { type?: string }).type === 'field' || (target as { type?: string }).type === 'discard')) {
                 resolvedEffect = {
                     ...resolvedEffect,
                     [requirement.targetProperty]: resolvedEnergy,
                 };
-                break;
+            } else if (target && typeof target === 'object' && (target as { type?: string }).type === 'fixed') {
+                // Resolve fixed field targets before apply() so handler receives 'resolved' type
+                const resolution = FieldTargetResolver.resolveSingleTarget(target as SingleFieldTarget, controllers, context);
+                if (resolution && resolution.type === 'resolved') {
+                    resolvedEffect = {
+                        ...resolvedEffect,
+                        [requirement.targetProperty]: resolution,
+                    };
+                }
+            } else if (target && typeof target === 'object'
+                && ((target as FieldTarget).type === 'single-choice' || (target as FieldTarget).type === 'multi-choice' || (target as FieldTarget).type === 'all-matching')) {
+                // Another (destination) target also needs resolving now that the source is known
+                const resolution = FieldTargetResolver.resolveTarget(target as FieldTarget, controllers, context);
+                if (resolution.type === 'requires-selection') {
+                    pendingFieldRequirement = { targetProperty: requirement.targetProperty, target: target as FieldTarget };
+                } else {
+                    resolvedEffect = {
+                        ...resolvedEffect,
+                        [requirement.targetProperty]: this.convertResolutionToResolvedTargets(resolution, context),
+                    };
+                }
             }
+        }
+
+        if (pendingFieldRequirement) {
+            const resolution = FieldTargetResolver.resolveTarget(pendingFieldRequirement.target, controllers, context);
+            const nextAvailableTargets = resolution.type === 'requires-selection' ? resolution.availableTargets : [];
+            const nextCount = pendingFieldRequirement.target.type === 'multi-choice' ? pendingFieldRequirement.target.count : 1;
+            const nextAllowRepeats = pendingFieldRequirement.target.type === 'multi-choice' ? pendingFieldRequirement.target.allowRepeats : undefined;
+            const nextPendingSelection: PendingFieldSelection = {
+                selectionType: 'field',
+                effect: resolvedEffect,
+                originalContext,
+                continuationEffects: pendingSelection.continuationEffects,
+                count: nextCount,
+                availableTargets: nextAvailableTargets,
+                allowRepeats: nextAllowRepeats,
+            };
+            controllers.turnState.setPendingSelection(nextPendingSelection);
+            return;
         }
 
         handler.apply(controllers, resolvedEffect, context);

--- a/src/effects/handlers/energy-transfer-effect-handler.ts
+++ b/src/effects/handlers/energy-transfer-effect-handler.ts
@@ -44,7 +44,7 @@ export class EnergyTransferEffectHandler extends AbstractEffectHandler<EnergyTra
         const sourceAvailable = EnergyTargetResolver.isTargetAvailable(effect.source, handlerData, context, cardRepository);
         // Use FieldTargetResolver to check if target is available
         const targetAvailable = FieldTargetResolver.isTargetAvailable(effect.target, handlerData, context, cardRepository);
-        
+
         return sourceAvailable && targetAvailable;
     }
     
@@ -59,32 +59,49 @@ export class EnergyTransferEffectHandler extends AbstractEffectHandler<EnergyTra
             throw new Error(`Expected resolved target, got ${resolvedTarget?.type || 'undefined'}`);
         }
 
-        const targetFieldTarget = resolvedTarget.targets[0];
-        const targetInstanceId = controllers.field.getFieldInstanceId(targetFieldTarget.playerId, targetFieldTarget.fieldIndex);
-
-        if (!targetInstanceId) {
-            controllers.players.messageAll({
-                type: 'status',
-                components: [ `${context.effectName} could not resolve transfer target!` ],
-            });
-            return;
+        // Flatten the resolved source(s) into individual 1-unit energy cards, preserving origin
+        // so each unit can be removed correctly (field creature vs. discard pile) when consumed.
+        type EnergyUnit = { energyType: AttachableEnergyType; location: 'field' | 'discard'; playerId: number; fieldIndex: number };
+        const units: EnergyUnit[] = [];
+        for (const sourceTarget of resolvedSource.targets) {
+            const location = sourceTarget.location ?? 'field';
+            for (const [ energyType, amount ] of Object.entries(sourceTarget.energy) as Array<[ AttachableEnergyType, number ]>) {
+                for (let i = 0; i < (amount || 0); i++) {
+                    units.push({ energyType, location, playerId: sourceTarget.playerId, fieldIndex: sourceTarget.fieldIndex });
+                }
+            }
         }
 
+        /*
+         * Single destination: move every sourced unit there (e.g. "move energy from X to Y").
+         * Multiple destinations: spread 1 unit to each, in order, until either the pool or the
+         * destination list is exhausted (e.g. "move 2 Lightning Energy... 1 each to 2 Benched Pokemon").
+         */
+        const unitsPerDestination = resolvedTarget.targets.length === 1 ? units.length : 1;
+
         let transferred = 0;
-        for (const sourceTarget of resolvedSource.targets) {
-            const sourceInstanceId = controllers.field.getFieldInstanceId(sourceTarget.playerId, sourceTarget.fieldIndex);
-            if (!sourceInstanceId) {
-                continue; 
+        for (const destination of resolvedTarget.targets) {
+            const destInstanceId = controllers.field.getFieldInstanceId(destination.playerId, destination.fieldIndex);
+            if (!destInstanceId) {
+                continue;
             }
 
-            for (const [ energyType, amount ] of Object.entries(sourceTarget.energy) as Array<[ AttachableEnergyType, number ]>) {
-                if (amount > 0 && controllers.energy.transferEnergyBetweenInstances(
-                    sourceInstanceId,
-                    targetInstanceId,
-                    energyType,
-                    amount,
-                )) {
-                    transferred += amount;
+            for (let i = 0; i < unitsPerDestination; i++) {
+                const unit = units.shift();
+                if (!unit) {
+                    break;
+                }
+
+                let success: boolean;
+                if (unit.location === 'discard') {
+                    success = controllers.energy.attachEnergyFromDiscard(unit.playerId, destInstanceId, { [unit.energyType]: 1 });
+                } else {
+                    const sourceInstanceId = controllers.field.getFieldInstanceId(unit.playerId, unit.fieldIndex);
+                    success = !!sourceInstanceId && controllers.energy.transferEnergyBetweenInstances(sourceInstanceId, destInstanceId, unit.energyType, 1);
+                }
+
+                if (success) {
+                    transferred += 1;
                 }
             }
         }

--- a/src/effects/interfaces/effect-handler-interface.ts
+++ b/src/effects/interfaces/effect-handler-interface.ts
@@ -20,7 +20,7 @@ export type EffectHandlerMap = {
  * This separates what needs resolution from how to resolve it.
  */
 export function isEnergyResolutionTarget(target: FieldTarget | EnergyTarget): target is EnergyTarget {
-    return 'fieldTarget' in target && 'count' in target;
+    return target.type === 'field' || target.type === 'discard';
 }
 
 export interface ResolutionRequirement {

--- a/src/effects/pending-selection-types.ts
+++ b/src/effects/pending-selection-types.ts
@@ -43,6 +43,8 @@ export type PendingFieldSelection = BasePendingSelection & {
     maxTargets?: number;
     /** The field positions available for selection, pre-computed at selection creation time */
     availableTargets: TargetOption[];
+    /** When true, the same option may be selected more than once (a multiset selection) */
+    allowRepeats?: boolean;
 };
 
 /**

--- a/src/effects/target-resolvers/energy-target-resolver.ts
+++ b/src/effects/target-resolvers/energy-target-resolver.ts
@@ -1,4 +1,4 @@
-import { EnergyTarget, EnergyCriteria } from '../../repository/targets/energy-target.js';
+import { EnergyTarget, EnergyCriteria, DiscardEnergyTarget, FieldEnergyTarget } from '../../repository/targets/energy-target.js';
 import { Controllers } from '../../controllers/controllers.js';
 import { EffectContext } from '../effect-context.js';
 import { AttachableEnergyType } from '../../repository/energy-types.js';
@@ -31,7 +31,10 @@ export type ResolvedMultiEnergyTarget = {
     type: 'resolved-multi';
     targets: Array<{
         playerId: number;
+        /** -1 sentinel when location is 'discard' (no field creature) */
         fieldIndex: number;
+        /** Where this energy came from; defaults to 'field' when absent (existing callers predate discard sourcing) */
+        location?: 'field' | 'discard';
         energy: Partial<Record<AttachableEnergyType, number>>;
     }>;
 };
@@ -46,16 +49,31 @@ export type EnergyTargetResolutionResult =
 
 /**
  * Represents an energy selection option for the player.
+ *
+ * Two distinct kinds of choice are modeled with this same shape:
+ *  - "which source" (location: 'field'): player picks which creature to take energy from;
+ *    `availableEnergy` holds every matching type/amount on that creature.
+ *  - "which type" (energyType set): the source (a single creature, or the discard pile) is
+ *    already known, but it holds more than one matching energy type, so the player picks
+ *    which type to take; `availableEnergy` holds just that one type capped at the requested count.
  */
 export type EnergyOption = {
     /** Field position of the energy */
     playerId: number;
+    /** Field position of the energy; -1 sentinel when location is 'discard' (no field creature) */
     fieldIndex: number;
+    /** Where this energy is coming from */
+    location: 'field' | 'discard';
     /** Available energy that matches criteria */
     availableEnergy: Partial<Record<AttachableEnergyType, number>>;
     /** Display name for the option */
     displayName: string;
+    /** Set when this option represents choosing a specific type from an already-known single source */
+    energyType?: AttachableEnergyType;
 };
+
+/** Sentinel fieldIndex used for discard-pile-sourced EnergyOptions/resolved targets (no field creature). */
+export const DISCARD_FIELD_INDEX = -1;
 
 /**
  * Centralized class for handling energy target resolution.
@@ -79,7 +97,77 @@ export class EnergyTargetResolver {
             return { type: 'no-valid-targets' };
         }
 
+        if (target.type === 'discard') {
+            return this.resolveDiscardEnergyTarget(target, controllers, context);
+        }
+
         return this.resolveFieldEnergyTarget(target, controllers, context);
+    }
+
+    /**
+     * Resolves an energy target sourced from the player's discard pile.
+     * If the matching energy spans more than one type, this surfaces a type-choice
+     * `requires-selection` result instead of silently auto-picking a type.
+     */
+    private static resolveDiscardEnergyTarget(
+        target: DiscardEnergyTarget,
+        controllers: Controllers,
+        context: EffectContext,
+    ): EnergyTargetResolutionResult {
+        const playerId = context.sourcePlayer;
+        const discarded = controllers.energy.getDiscardedEnergy(playerId);
+        const availableEnergy = this.filterEnergyByCriteria(discarded, target.criteria);
+
+        if (this.getTotalEnergy(availableEnergy) === 0) {
+            return { type: 'no-valid-targets' };
+        }
+
+        return this.resolvePoolWithTypeChoice(
+            playerId,
+            DISCARD_FIELD_INDEX,
+            'discard',
+            'Discard pile',
+            availableEnergy,
+            target.count,
+        );
+    }
+
+    /**
+     * Resolves a known single energy pool (one creature, or the discard pile), choosing between
+     * auto-resolving (0 or 1 matching type present) and surfacing a type-choice selection
+     * (2+ matching types present).
+     */
+    private static resolvePoolWithTypeChoice(
+        playerId: number,
+        fieldIndex: number,
+        location: 'field' | 'discard',
+        displayName: string,
+        availableEnergy: Partial<Record<AttachableEnergyType, number>>,
+        count: number,
+    ): EnergyTargetResolutionResult {
+        const typesPresent = (Object.keys(availableEnergy) as AttachableEnergyType[]).filter(type => (availableEnergy[type] || 0) > 0);
+        const totalAvailable = this.getTotalEnergy(availableEnergy);
+
+        // No real choice when there's only one matching type, or when `count` takes everything anyway.
+        if (typesPresent.length <= 1 || count >= totalAvailable) {
+            const selectedEnergy = this.selectEnergy(availableEnergy, count);
+            return {
+                type: 'resolved-multi',
+                targets: [{ playerId, fieldIndex, location, energy: selectedEnergy }],
+            };
+        }
+
+        // 2+ matching types: let the player choose which type to take (up to `count` of it).
+        const typeOptions: EnergyOption[] = typesPresent.map(type => ({
+            playerId,
+            fieldIndex,
+            location,
+            energyType: type,
+            availableEnergy: { [type]: Math.min(availableEnergy[type] || 0, count) },
+            displayName: `${displayName} (${Math.min(availableEnergy[type] || 0, count)}x ${type})`,
+        }));
+
+        return { type: 'requires-selection', availableTargets: typeOptions };
     }
 
     /**
@@ -91,7 +179,7 @@ export class EnergyTargetResolver {
      * @returns Resolution result
      */
     private static resolveFieldEnergyTarget(
-        target: EnergyTarget,
+        target: FieldEnergyTarget,
         controllers: Controllers,
         context: EffectContext,
     ): EnergyTargetResolutionResult {
@@ -121,6 +209,7 @@ export class EnergyTargetResolver {
                     energyOptions.push({
                         playerId: option.playerId,
                         fieldIndex: option.fieldIndex,
+                        location: 'field',
                         availableEnergy,
                         displayName: `${option.name} (${option.position})`,
                     });
@@ -131,14 +220,10 @@ export class EnergyTargetResolver {
                 return { type: 'no-valid-targets' };
             }
 
-            // If only one option, auto-resolve it as resolved-multi
+            // If only one option, auto-resolve it (still may require a type choice on that one creature)
             if (energyOptions.length === 1) {
                 const opt = energyOptions[0];
-                const selectedEnergy = this.selectEnergy(opt.availableEnergy, target.count);
-                return {
-                    type: 'resolved-multi',
-                    targets: [{ playerId: opt.playerId, fieldIndex: opt.fieldIndex, energy: selectedEnergy }],
-                };
+                return this.resolvePoolWithTypeChoice(opt.playerId, opt.fieldIndex, 'field', opt.displayName, opt.availableEnergy, target.count);
             }
 
             return { type: 'requires-selection', availableTargets: energyOptions };
@@ -148,7 +233,7 @@ export class EnergyTargetResolver {
         if (fieldResolution.type === 'resolved' && fieldResolution.targets.length > 0) {
             const fieldTarget = fieldResolution.targets[0];
             const creature = controllers.field.getRawCardByPosition(fieldTarget.playerId, fieldTarget.fieldIndex);
-            
+
             if (!creature) {
                 return { type: 'no-valid-targets' };
             }
@@ -161,19 +246,21 @@ export class EnergyTargetResolver {
                 return { type: 'no-valid-targets' };
             }
 
-            // Select energy up to the requested count
-            const selectedEnergy = target.random
-                ? this.selectEnergyRandomly(availableEnergy, target.count, controllers)
-                : this.selectEnergy(availableEnergy, target.count);
+            // Random selection bypasses type choice by design (the whole point is non-determinism)
+            if (target.random) {
+                const selectedEnergy = this.selectEnergyRandomly(availableEnergy, target.count, controllers);
+                return {
+                    type: 'resolved-multi',
+                    targets: [{
+                        playerId: fieldTarget.playerId,
+                        fieldIndex: fieldTarget.fieldIndex,
+                        location: 'field',
+                        energy: selectedEnergy,
+                    }],
+                };
+            }
 
-            return {
-                type: 'resolved-multi',
-                targets: [{
-                    playerId: fieldTarget.playerId,
-                    fieldIndex: fieldTarget.fieldIndex,
-                    energy: selectedEnergy,
-                }],
-            };
+            return this.resolvePoolWithTypeChoice(fieldTarget.playerId, fieldTarget.fieldIndex, 'field', 'creature', availableEnergy, target.count);
         }
 
         // Handle all-matching targets
@@ -399,6 +486,15 @@ export class EnergyTargetResolver {
     ): boolean {
         if (!target) {
             return false;
+        }
+
+        if (target.type === 'discard') {
+            const discarded = handlerData.energy?.discardedEnergy?.[context.sourcePlayer];
+            if (!discarded) {
+                return false;
+            }
+            const filtered = this.filterEnergyByCriteria(discarded, target.criteria);
+            return this.getTotalEnergy(filtered) > 0;
         }
 
         // Check if field target has any creatures with matching energy

--- a/src/effects/target-resolvers/field-target-resolver.ts
+++ b/src/effects/target-resolvers/field-target-resolver.ts
@@ -206,7 +206,41 @@ export class FieldTargetResolver {
                 }],
             };
         }
-        
+
+        // For multi-choice targets, auto-resolve when there is exactly one possible combination
+        if (target.type === 'multi-choice') {
+            if (target.allowRepeats) {
+                // With repeats allowed, the only case with no real choice is a single available option:
+                // however many units are being placed, they all have to go to that one option.
+                if (availableTargets.length === 1) {
+                    const only = availableTargets[0];
+                    return {
+                        type: 'resolved',
+                        targets: Array.from({ length: target.count }, () => ({
+                            playerId: only.playerId,
+                            fieldIndex: only.fieldIndex,
+                        })),
+                    };
+                }
+            } else {
+                if (availableTargets.length < target.count) {
+                    // Not enough distinct options to satisfy the required count without repeats
+                    return { type: 'no-valid-targets' };
+                }
+                // Without repeats, the only case with no real choice is needing exactly as many
+                // targets as are available - there's only one way to pick all of them.
+                if (availableTargets.length === target.count) {
+                    return {
+                        type: 'resolved',
+                        targets: availableTargets.map(t => ({
+                            playerId: t.playerId,
+                            fieldIndex: t.fieldIndex,
+                        })),
+                    };
+                }
+            }
+        }
+
         // Otherwise, requires selection
         return {
             type: 'requires-selection',
@@ -756,8 +790,9 @@ export class FieldTargetResolver {
                     effect: effect,
                     originalContext: context,
                     continuationEffects: context.selectionContinuationEffects,
-                    count: 1,
+                    count: targetToUse.type === 'multi-choice' ? targetToUse.count : 1,
                     availableTargets: resolution.availableTargets,
+                    allowRepeats: targetToUse.type === 'multi-choice' ? targetToUse.allowRepeats : undefined,
                 });
                 return true;
             }

--- a/src/event-handler.ts
+++ b/src/event-handler.ts
@@ -1078,7 +1078,26 @@ export const eventHandler = buildEventHandler<Controllers, ResponseMessage>({
                     if (!pendingSelection || !isPendingFieldSelection(pendingSelection)) {
                         return true; // No pending field selection - validation fails
                     }
-                    
+
+                    // Validate the number of selected targets is within the required range
+                    const minTargets = pendingSelection.minTargets ?? pendingSelection.count;
+                    const maxTargets = pendingSelection.maxTargets ?? pendingSelection.count;
+                    if (message.targets.length < minTargets || message.targets.length > maxTargets) {
+                        return true; // Wrong number of targets selected
+                    }
+
+                    // Validate no target was selected more than once (unless repeats are explicitly allowed)
+                    if (!pendingSelection.allowRepeats) {
+                        const seen = new Set<string>();
+                        for (const target of message.targets) {
+                            const key = `${target.playerId}:${target.fieldIndex}`;
+                            if (seen.has(key)) {
+                                return true; // Duplicate target selected
+                            }
+                            seen.add(key);
+                        }
+                    }
+
                     // Validate every selected target is in the pre-computed available targets list
                     for (const target of message.targets) {
                         const found = pendingSelection.availableTargets.find(
@@ -1088,7 +1107,7 @@ export const eventHandler = buildEventHandler<Controllers, ResponseMessage>({
                             return true; // Selected target not in available options
                         }
                     }
-                    
+
                     return false; // Valid selection
                 }),
             ],
@@ -1109,8 +1128,7 @@ export const eventHandler = buildEventHandler<Controllers, ResponseMessage>({
                 const hasNewPendingSelection = EffectApplier.resumeEffectWithSelection(
                     controllers,
                     pendingSelection,
-                    message.targetPlayerId,
-                    message.targetCreatureIndex,
+                    message.targets,
                 );
                 
                 // Only clear pending selection if we didn't set up a new one
@@ -1140,10 +1158,10 @@ export const eventHandler = buildEventHandler<Controllers, ResponseMessage>({
                     // Validate every selected target is in the available energy list
                     for (const sel of message.selectedTargets) {
                         const found = pendingSelection.availableEnergy.find(
-                            opt => opt.playerId === sel.playerId && opt.fieldIndex === sel.fieldIndex,
+                            opt => opt.playerId === sel.playerId && opt.fieldIndex === sel.fieldIndex && opt.energyType === sel.energyType,
                         );
                         if (!found) {
-                            return true; // Selected creature is not in the available options
+                            return true; // Selected option is not in the available options
                         }
                     }
                     

--- a/src/handlers/default-bot-handler.ts
+++ b/src/handlers/default-bot-handler.ts
@@ -180,10 +180,11 @@ export class DefaultBotHandler extends GameHandler {
         }
         
         const count = pendingSelection.count || 1;
-        // Select the first N available energy options (creature-level)
+        // Select the first N available energy options (creature- or type-level)
         const selectedTargets = pendingSelection.availableEnergy.slice(0, count).map(opt => ({
             playerId: opt.playerId,
             fieldIndex: opt.fieldIndex,
+            energyType: opt.energyType,
         }));
         responsesQueue.push(new SelectEnergyResponseMessage(selectedTargets));
     }

--- a/src/handlers/intermediary-handler.ts
+++ b/src/handlers/intermediary-handler.ts
@@ -275,7 +275,10 @@ export class IntermediaryHandler extends GameHandler {
             };
         });
         
-        const prompt = pendingSelection.prompt || `Select ${count} creature${count !== 1 ? 's' : ''} to take energy from:`;
+        const isTypeChoice = availableEnergy[0]?.energyType !== undefined;
+        const prompt = pendingSelection.prompt || (isTypeChoice
+            ? `Select ${count} energy type${count !== 1 ? 's' : ''} to take:`
+            : `Select ${count} creature${count !== 1 ? 's' : ''} to take energy from:`);
         
         if (count === 1) {
             const [ sent, received ] = this.intermediary.form({
@@ -289,6 +292,7 @@ export class IntermediaryHandler extends GameHandler {
             responsesQueue.push(new SelectEnergyResponseMessage([{
                 playerId: selectedOpt.playerId,
                 fieldIndex: selectedOpt.fieldIndex,
+                energyType: selectedOpt.energyType,
             }]));
         } else {
             const [ sent, received ] = this.intermediary.form({
@@ -307,6 +311,7 @@ export class IntermediaryHandler extends GameHandler {
             const selectedTargets = selectedIndices.map(index => ({
                 playerId: availableEnergy[index].playerId,
                 fieldIndex: availableEnergy[index].fieldIndex,
+                energyType: availableEnergy[index].energyType,
             }));
             responsesQueue.push(new SelectEnergyResponseMessage(selectedTargets));
         }

--- a/src/messages/response/select-energy-response-message.ts
+++ b/src/messages/response/select-energy-response-message.ts
@@ -1,17 +1,19 @@
 import { Message } from '@cards-ts/core';
+import { AttachableEnergyType } from '../../repository/energy-types.js';
 
 /**
- * Response message for selecting energy to discard or move.
- * The selection is expressed as the creatures whose energy should be used;
- * the specific energy amounts are determined by the handler from the pending
- * selection's availableEnergy list.
+ * Response message for selecting energy to discard, move, or take from the discard pile.
+ * Each entry selects an EnergyOption from the pending selection's availableEnergy list, matched
+ * by (playerId, fieldIndex, energyType). `energyType` is set when the option represents choosing
+ * a specific energy type from an already-known single source (e.g. discard pile with 2+ types);
+ * it's omitted when the option represents choosing which creature to take energy from.
  */
 export class SelectEnergyResponseMessage extends Message {
     readonly type = 'select-energy-response';
 
     constructor(
-        public readonly selectedTargets: Array<{ playerId: number; fieldIndex: number }>,
+        public readonly selectedTargets: Array<{ playerId: number; fieldIndex: number; energyType?: AttachableEnergyType }>,
     ) {
-        super([ `Selected energy from ${selectedTargets.length} creature${selectedTargets.length !== 1 ? 's' : ''}` ]);
+        super([ `Selected energy from ${selectedTargets.length} option${selectedTargets.length !== 1 ? 's' : ''}` ]);
     }
 }

--- a/src/repository/targets/energy-target.ts
+++ b/src/repository/targets/energy-target.ts
@@ -31,7 +31,20 @@ export type FieldEnergyTarget<TContextualRefs extends string = string> = {
 };
 
 /**
- * Union type for all energy target types.
- * Currently only includes field-based energy targeting.
+ * Represents an energy target sourced from a player's discard pile (no field creature involved).
+ * If the matching energy in the discard pile spans more than one type, the resolver will
+ * prompt the player to choose which type to take (see EnergyTargetResolver).
  */
-export type EnergyTarget<TContextualRefs extends string = string> = FieldEnergyTarget<TContextualRefs>;
+export type DiscardEnergyTarget = {
+    type: 'discard';
+    /** Criteria for which energy types to target; omit for any type */
+    criteria?: EnergyCriteria;
+    /** Number of energy to target */
+    count: number;
+};
+
+/**
+ * Union type for all energy target types: field-based (energy already attached to a creature)
+ * or discard-based (energy sitting in the player's discard pile).
+ */
+export type EnergyTarget<TContextualRefs extends string = string> = FieldEnergyTarget<TContextualRefs> | DiscardEnergyTarget;

--- a/src/repository/targets/field-target.ts
+++ b/src/repository/targets/field-target.ts
@@ -65,6 +65,13 @@ export type MultiChoiceFieldTarget = {
     chooser: 'self' | 'opponent';
     criteria: FieldTargetCriteria;
     count: number;
+    /**
+     * When true, the same option may be chosen more than once (a multiset of size
+     * `count` rather than `count` distinct options) — e.g. distributing several
+     * interchangeable energy units across chosen creatures in any combination,
+     * including stacking all of them on one creature.
+     */
+    allowRepeats?: boolean;
 };
 
 /**


### PR DESCRIPTION
- Fix EnergyTransferEffect/EffectApplier to honor multi-choice field selections fully instead of collapsing to a single target, and add proper count-range/duplicate validation for select-target-response (previously any count would validate).
- Add DiscardEnergyTarget and generalize energy-type resolution so a player is prompted to choose which energy type to move whenever a known source (a creature or the discard pile) holds 2+ matching types, instead of silently auto-picking one.
- Add `allowRepeats` to multi-choice field targets so a card can let a player distribute several interchangeable energy units across targets in one decision (including stacking all of them on a single target), and generalize multi-choice auto-resolution to skip prompting whenever there is only one possible outcome (no repeats: available options exactly match the required count; with repeats: only one target exists).